### PR TITLE
14-implement-multi-workspace-support-for-graph-sessions

### DIFF
--- a/graph_explorer/webgraph/static/style.css
+++ b/graph_explorer/webgraph/static/style.css
@@ -56,6 +56,10 @@ a:hover {
   color: #444;
 }
 
+.menu strong {
+  margin-left: 1.5rem;
+}
+
 .main {
   display: flex;
   flex: 1;
@@ -89,10 +93,6 @@ a:hover {
   border-radius: 8px;
   transition: 0.3s;
   color: #333;
-}
-
-.sidebar ul li a:hover {
-  background: #f0f0f0;
 }
 
 .content {
@@ -196,4 +196,82 @@ a:hover {
   color: #0078ff;
   font-weight: bold;
   text-decoration: none;
+}
+
+.workspace-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.workspace-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-left: 0.8rem;
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+  transition: 0.3s;
+}
+
+.workspace-item a,
+.workspace-item strong {
+  font-size: 1rem;
+  color: #333;
+  flex-grow: 1;
+}
+
+.workspace-item.active {
+  background: #e8f3ff;
+  font-weight: 600;
+  color: #0078ff;
+}
+
+.workspace-item:hover {
+  background: #f5f5f5;
+}
+
+.inline-form {
+  margin: 0;
+}
+
+.delete-btn {
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  color: #888;
+  cursor: pointer;
+  margin-left: 0.5rem;
+  transition: 0.2s;
+}
+
+.delete-btn:hover {
+  color: #e63946 !important;
+  transform: scale(1.2);
+}
+
+.add-workspace-form {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-top: 1rem;
+}
+
+.workspace-input {
+  width: 100%;
+  padding: 0.7rem;
+  margin-top: 0.3rem;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+  background: #fff;
+  color: #222;
+}
+
+.workspace-add {
+  margin-top: 0.3rem;
+}
+
+.file-upload-container {
+  padding-bottom: 0;
 }

--- a/graph_explorer/webgraph/templates/base.html
+++ b/graph_explorer/webgraph/templates/base.html
@@ -18,7 +18,11 @@
         <div class="menu">
             {% if datasource_plugins %}
                 {% for p in datasource_plugins %}
-                    <a href="{% url 'datasource_plugin' id=p.identifier %}">{{ p.name }}</a>
+                    {% if p.identifier == active_datasource %}
+                        <strong>{{ p.name }}</strong>
+                    {% else %}
+                        <a href="{% url 'datasource_plugin' id=p.identifier %}">{{ p.name }}</a>
+                    {% endif %}
                 {% endfor %}
             {% else %}
                 <span>No data sources</span>
@@ -26,7 +30,11 @@
 
             {% if visualizer_plugins %}
                 {% for p in visualizer_plugins %}
-                    <a href="{% url 'visualizer_plugin' id=p.identifier %}">{{ p.name }}</a>
+                    {% if p.identifier == active_visualizer %}
+                        <strong>{{ p.name }}</strong>
+                    {% else %}
+                        <a href="{% url 'visualizer_plugin' id=p.identifier %}">{{ p.name }}</a>
+                    {% endif %}
                 {% endfor %}
             {% else %}
                 <span>No visualizers</span>
@@ -36,18 +44,42 @@
 
     <div class="main">
         <div class="sidebar glass">
-            <ul>
-                <li><a href="{% url 'graph_layout' %}">Graph Layout</a></li>
+            <h3>Workspaces</h3>
+            <ul class="workspace-list">
+            {% for name, ws in workspaces.items %}
+                {% if name %}
+                <li class="workspace-item {% if name == active_workspace %}active{% endif %}">
+                    {% if name == active_workspace %}
+                        <strong>{{ name }}</strong>
+                    {% else %}
+                        <a href="{% url 'select_workspace' name=name %}">{{ name }}</a>
+                    {% endif %}
+                    <form action="{% url 'delete_workspace' name=name %}" method="post" class="inline-form">
+                        {% csrf_token %}
+                        <button type="submit" class="btn delete-btn" title="Remove workspace">&times;</button>
+                    </form>
+                </li>
+                {% endif %}
+            {% endfor %}
             </ul>
+
+            <form action="{% url 'add_workspace' %}" method="get" class="add-workspace-form">
+                <input type="text" name="name" placeholder="New workspace" class="workspace-input">
+                <button type="submit" class="btn primary workspace-add">Add</button>
+            </form>
+
             {% block links %}{% endblock %}
         </div>
 
         <div class="content">
-            <div class="controls glass card">
-            <h3>Upload</h3>
+            <div class="controls glass card file-upload-container">
             <form action="{% url 'upload_file' %}" method="post" enctype="multipart/form-data">
                 {% csrf_token %}
-                <label for="upload">Upload File</label>
+                {% if uploaded_file_name %}
+                    <label>Currently loaded: <strong>{{ uploaded_file_name }}</strong></label>
+                {% else %}
+                    <label for="upload">Upload File</label>
+                {% endif %}
                 <input type="file" name="data_file" accept="*">
                 <div class="buttons">
                     <button type="submit" class="btn primary">Upload</button>
@@ -87,22 +119,25 @@
             <div class="active-filters glass card">
                 <h4>Active Queries</h4>
                 <div class="chips">
-                    {% for s in request.session.searches %}
-                    <span class="chip">Search: "{{ s }}"
-                        <a href="{% url 'remove_search' forloop.counter0 %}">&times;</a>
-                    </span>
-                    {% endfor %}
-                    {% for f in request.session.filters %}
-                    <span class="chip">Filter: {{ f.attr }} {{ f.op }} {{ f.val }}
-                        <a href="{% url 'remove_filter' forloop.counter0 %}">&times;</a>
-                    </span>
-                    {% endfor %}
+                    {% if active_workspace_data %}
+                        {% for s in active_workspace_data.searches %}
+                        <span class="chip">Search: "{{ s }}"
+                            <a href="{% url 'remove_search' forloop.counter0 %}">&times;</a>
+                        </span>
+                        {% endfor %}
+                        {% for f in active_workspace_data.filters %}
+                        <span class="chip">Filter: {{ f.attr }} {{ f.op }} {{ f.val }}
+                            <a href="{% url 'remove_filter' forloop.counter0 %}">&times;</a>
+                        </span>
+                        {% endfor %}
+                    {% endif %}
                 </div>
             </div>
         </div>
         <div class="active-filters glass card">
-
-        {% block content %}{% endblock %}
+            <h1>Graph Explorer</h1>
+            {{ graph_view_header|safe }}
+            {{ graph_view_body|safe }}
         </div>
     </div>
 </div>

--- a/graph_explorer/webgraph/urls.py
+++ b/graph_explorer/webgraph/urls.py
@@ -3,9 +3,11 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name="index"),
+    path('workspace/add', views.add_workspace, name="add_workspace"),
+    path('workspace/select/<str:name>', views.select_workspace, name="select_workspace"),
+    path('workspace/delete/<str:name>', views.delete_workspace, name="delete_workspace"),
     path('plugin/datasource/<str:id>', views.datasource_plugin, name="datasource_plugin"),
     path('plugin/visualizer/<str:id>', views.visualizer_plugin, name="visualizer_plugin"),
-    path('layout/simple', views.graph_layout, name="graph_layout"),
     path('upload', views.upload_file, name="upload_file"),
     path('query', views.query_graph, name="query_graph"),
     path('reset', views.reset_graph, name="reset_graph"),

--- a/graph_explorer/webgraph/views.py
+++ b/graph_explorer/webgraph/views.py
@@ -6,121 +6,166 @@ from graph.use_cases.plugin_recognition import PluginService
 from graph.use_cases.graph_main_view import MainView
 from .apps import datasource_group, visualizer_group
 
+def _get_active_workspace(request):
+    workspaces = request.session.get("workspaces", {})
+    active = request.session.get("active_workspace")
+    if not active or active not in workspaces:
+        return None, workspaces
+    return workspaces[active], workspaces
 
 def index(request):
     plugin_service: PluginService = apps.get_app_config('webgraph').plugin_service
     datasource_plugins = plugin_service.plugins[datasource_group]
     visualizer_plugins = plugin_service.plugins[visualizer_group]
+
+    workspace, workspaces = _get_active_workspace(request)
+    graph_view_header, graph_view_body = "", ""
+    uploaded_file_name = None
+
+    if workspace:
+        datasource_id = workspace.get("datasource")
+        visualizer_id = workspace.get("visualizer")
+        selected_file = workspace.get("file")
+        if selected_file:
+            uploaded_file_name = os.path.basename(selected_file)
+        if datasource_id and visualizer_id:
+            graph_view = MainView(plugin_service)
+            graph_view_header, graph_view_body = graph_view.render(
+                datasource_id,
+                visualizer_id,
+                file_path=selected_file,
+                request=request,
+                workspace=workspace,
+            )
+
     return render(request, 'index.html', {
         'title': 'Graph Explorer',
         'datasource_plugins': datasource_plugins,
-        'visualizer_plugins': visualizer_plugins
+        'visualizer_plugins': visualizer_plugins,
+        'graph_view_header': graph_view_header,
+        'graph_view_body': graph_view_body,
+        'workspaces': workspaces,
+        'active_workspace': request.session.get("active_workspace"),
+        'active_datasource': workspace.get("datasource") if workspace else None,
+        'active_visualizer': workspace.get("visualizer") if workspace else None,
+        'uploaded_file_name': uploaded_file_name,
+        'active_workspace_data': workspace,
     })
 
+def add_workspace(request):
+    name = request.GET.get("name", f"Workspace {len(request.session.get('workspaces', {})) + 1}")
+    workspaces = request.session.get("workspaces", {})
+    if name not in workspaces:
+        workspaces[name] = {}
+    request.session["workspaces"] = workspaces
+    request.session["active_workspace"] = name
+    request.session.modified = True
+    return redirect("index")
+
+def select_workspace(request, name):
+    workspaces = request.session.get("workspaces", {})
+    if name in workspaces:
+        request.session["active_workspace"] = name
+        request.session.modified = True
+    return redirect("index")
 
 def datasource_plugin(request, id):
-    request.session['selected_datasource_plugin'] = id
+    workspace, workspaces = _get_active_workspace(request)
+    if workspace is not None:
+        workspace["datasource"] = id
+        request.session["workspaces"] = workspaces
+        request.session.modified = True
     return redirect('index')
-
 
 def visualizer_plugin(request, id):
-    request.session['selected_visualizer_plugin'] = id
+    workspace, workspaces = _get_active_workspace(request)
+    if workspace is not None:
+        workspace["visualizer"] = id
+        request.session["workspaces"] = workspaces
+        request.session.modified = True
     return redirect('index')
 
-
-def graph_layout(request):
-    selected_datasource_plugin = request.session.get('selected_datasource_plugin')
-    selected_visualizer_plugin = request.session.get('selected_visualizer_plugin')
-    selected_file = request.session.get("selected_file", None)
-
-    plugin_service: PluginService = apps.get_app_config('webgraph').plugin_service
-    datasource_plugins = plugin_service.plugins[datasource_group]
-    visualizer_plugins = plugin_service.plugins[visualizer_group]
-
-    graph_view = MainView(plugin_service)
-
-    header, body = graph_view.render(
-        selected_datasource_plugin,
-        selected_visualizer_plugin,
-        file_path=selected_file,
-        request=request,
-    )
-
-    return render(request, 'graph-simple-layout.html', {
-        'title': 'Graph Layout',
-        'datasource_plugins': datasource_plugins,
-        'visualizer_plugins': visualizer_plugins,
-        'graph_view_header': header,
-        'graph_view_body': body
-    })
-
-
 def upload_file(request):
+    workspace, workspaces = _get_active_workspace(request)
     if request.method == "POST":
         if "data_file" not in request.FILES:
-            return HttpResponse(
-                "<script>alert('No file selected!'); window.location.href='/layout/simple';</script>"
-            )
+            return HttpResponse("<script>alert('No file selected!'); window.location.href='/';</script>")
         uploaded_file = request.FILES["data_file"]
-
         upload_dir = "uploads"
         os.makedirs(upload_dir, exist_ok=True)
-
         file_path = os.path.join(upload_dir, uploaded_file.name)
-
         with open(file_path, "wb+") as dest:
             for chunk in uploaded_file.chunks():
                 dest.write(chunk)
-
-        # čuvamo putanju bez obzira na tip
-        request.session["selected_file"] = file_path
-        return redirect("graph_layout")
-
+        if workspace is not None:
+            workspace["file"] = file_path
+            request.session["workspaces"] = workspaces
+            request.session.modified = True
+        return redirect("index")
     return render(request, "upload.html")
 
-
 def reset_graph(request):
-    request.session.pop("filters", None)
-    request.session.pop("searches", None)
-    return redirect("graph_layout")
-
+    workspace, workspaces = _get_active_workspace(request)
+    if workspace is not None:
+        workspace.pop("filters", None)
+        workspace.pop("searches", None)
+        request.session["workspaces"] = workspaces
+        request.session.modified = True
+    return redirect("index")
 
 def remove_filter(request, index):
-    filters = request.session.get("filters", [])
-    if 0 <= index < len(filters):
-        filters.pop(index)
-        request.session["filters"] = filters
-    return redirect("graph_layout")
-
+    workspace, workspaces = _get_active_workspace(request)
+    if workspace is not None:
+        filters = workspace.get("filters") or []
+        if 0 <= index < len(filters):
+            filters.pop(index)
+        workspace["filters"] = filters
+        request.session["workspaces"] = workspaces
+        request.session.modified = True
+    return redirect("index")
 
 def remove_search(request, index):
-    searches = request.session.get("searches", [])
-    if 0 <= index < len(searches):
-        searches.pop(index)
-        request.session["searches"] = searches
-    return redirect("graph_layout")
-
+    workspace, workspaces = _get_active_workspace(request)
+    if workspace is not None:
+        searches = workspace.get("searches") or []
+        if 0 <= index < len(searches):
+            searches.pop(index)
+        workspace["searches"] = searches
+        request.session["workspaces"] = workspaces
+        request.session.modified = True
+    return redirect("index")
 
 def query_graph(request):
-    if request.method == "POST":
+    workspace, workspaces = _get_active_workspace(request)
+    if request.method == "POST" and workspace is not None:
         try:
             if request.POST.get("search"):
-                searches = request.session.get("searches", [])
+                searches = workspace.get("searches") or []
+                searches = list(searches)
                 searches.append(request.POST["search"])
-                request.session["searches"] = searches
-
+                workspace["searches"] = searches
             if request.POST.get("filter1") and request.POST.get("operator") and request.POST.get("filter2"):
-                filters = request.session.get("filters", [])
+                filters = workspace.get("filters") or []
+                filters = list(filters)
                 filters.append({
                     "attr": request.POST["filter1"],
                     "op": request.POST["operator"],
                     "val": request.POST["filter2"]
                 })
-                request.session["filters"] = filters
-
+                workspace["filters"] = filters
+            request.session["workspaces"] = workspaces
+            request.session.modified = True
         except ValueError as e:
-            return HttpResponse(
-                f"<script>alert('{str(e)}'); window.location.href='/layout/simple';</script>"
-            )
+            return HttpResponse(f"<script>alert('{str(e)}'); window.location.href='/';</script>")
+    return redirect("index")
 
-    return redirect("graph_layout")
+def delete_workspace(request, name):
+    workspaces = request.session.get("workspaces", {})
+    active = request.session.get("active_workspace")
+    if name in workspaces:
+        del workspaces[name]
+        if active == name:
+            request.session["active_workspace"] = next(iter(workspaces), None)
+        request.session["workspaces"] = workspaces
+        request.session.modified = True
+    return redirect("index")

--- a/platform/graph/use_cases/filter_service.py
+++ b/platform/graph/use_cases/filter_service.py
@@ -1,14 +1,9 @@
 from datetime import datetime
-from graph.api.models import Graph, Node, Edge
-
+from graph.api.models import Graph
 
 class FilterService:
     @staticmethod
     def apply_filters(graph: Graph, filters: list[dict]) -> Graph:
-        """
-        Primeni listu filtera sukcesivno. 
-        Filter je dict oblika: {"attr": "age", "op": ">", "val": "30"}
-        """
         if not filters:
             return graph
 
@@ -23,45 +18,36 @@ class FilterService:
 
     @staticmethod
     def _parse_value(value: str):
-        """
-        Pokušaj da parsiraš vrednost u broj ili datum, 
-        ako ne uspe ostavi string.
-        """
         if value is None:
             return None
 
-        # pokušaj int
         try:
             return int(value)
         except ValueError:
             pass
 
-        # pokušaj float
         try:
             return float(value)
         except ValueError:
             pass
 
-        # pokušaj datetime (ISO ili dd.mm.yyyy)
         for fmt in ("%Y-%m-%d", "%d.%m.%Y", "%Y/%m/%d"):
             try:
                 return datetime.strptime(value, fmt)
             except ValueError:
                 continue
 
-        # fallback string
         return str(value)
 
     @staticmethod
     def _compare(left, op: str, right) -> bool:
-        """Uporedi dve vrednosti zavisno od operatora."""
         if op == "==": return left == right
         if op == "!=": return left != right
         if op == ">": return left > right
         if op == ">=": return left >= right
         if op == "<": return left < right
         if op == "<=": return left <= right
-        raise ValueError(f"Nepoznat operator: {op}")
+        raise ValueError(f"Unknown operator: {op}")
 
     @staticmethod
     def _apply_filter(graph: Graph, attr: str, op: str, val: str) -> Graph:
@@ -82,10 +68,8 @@ class FilterService:
                     filtered.add_node(node)
                     keep.add(node.node_id)
             except Exception:
-                # ako tipovi nisu kompatibilni, preskoči
                 continue
 
-        # Dodaj samo grane između čuvanih čvorova
         for e in graph.edges:
             if e.from_node.node_id in keep and (e.to_node is None or e.to_node.node_id in keep):
                 filtered.add_edge(e)

--- a/platform/graph/use_cases/graph_main_view.py
+++ b/platform/graph/use_cases/graph_main_view.py
@@ -17,8 +17,12 @@ class MainView(object):
             return "", ""
         
         request = kwargs.get("request")
-        if request and not request.session.get("searches") and not request.session.get("filters") and "reset" in request.GET:
-            return "", ""
+        workspace = kwargs.get("workspace")
+
+        if not workspace and request:
+            workspace_id = request.GET.get("workspace_id", "default")
+            all_workspaces = request.session.get("workspaces", {})
+            workspace = all_workspaces.get(workspace_id, {"searches": [], "filters": []})
 
         datasource_plugins = self.__plugin_service.plugins.get(DATASOURCE_GROUP, [])
         graph = None
@@ -27,18 +31,17 @@ class MainView(object):
             if plugin.identifier() == datasource_id:
                 try:
                     clean_kwargs = {k: v for k, v in kwargs.items() if v is not None}
-                    request = kwargs.get("request")
-                    print("REQUEST:", clean_kwargs)
                     graph = plugin.load(**clean_kwargs)
-                    if request:
-                        query = request.session.get("searches")
-                        if query:
-                            graph = SearchService.search(graph, query)
 
-                        filters = request.session.get("filters")
+                    if workspace:
+                        searches = workspace.get("searches", [])
+                        if searches:
+                            graph = SearchService.search(graph, searches)
+
+                        filters = workspace.get("filters", [])
                         if filters:
                             graph = FilterService.apply_filters(graph, filters)
-                            
+
                 except Exception as e:
                     print("Datasource plugin error:", e)
                     return "<h3>Error loading graph</h3>", ""


### PR DESCRIPTION
Hi team,
I've done some work and now we have:
- Added ability to manage multiple workspaces within the graph explorer  
- Persisted active workspace state (datasource, visualizer, searches, filters)  
- Updated template rendering to correctly highlight the active workspace  
- Ensured plugin selection (datasource/visualizer) is displayed in bold  
- Refactored context passing to avoid direct dict indexing in templates
