### PR TITLE
#13 [FEATURE] Cli Implemented

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "python.analysis.extraPaths": [
-        "./platform",
-        "./api"
-    ]
-}

--- a/data_source_plugin_xml/graph/xml_datasource/xml_datasource_plugin.py
+++ b/data_source_plugin_xml/graph/xml_datasource/xml_datasource_plugin.py
@@ -7,8 +7,10 @@ from graph.api.services.plugin import DataSourcePlugin
 
 class XMLNode(Node):
     """Node for XML plugin holding id and key-value attributes."""
+
     def __init__(self, node_id: str, values: dict, x: float = None, y: float = None):
         """Initialize XMLNode with optional coordinates."""
+        
         super().__init__(node_id, values, x, y)
 
 
@@ -19,26 +21,32 @@ class XMLEdge(Edge):
 
 class XMLGraph(Graph):
     """Simple Graph implementation for XML plugin."""
+
     def add_node(self, node: Node) -> None:
         """Add a node to the graph."""
+
         self._nodes[node.node_id] = node
 
     def add_edge(self, edge: Edge) -> None:
         """Add an edge to the graph."""
+
         self._edges.append(edge)
 
     def get_neighbors(self, node_id: str):
         """Return a list of neighbor nodes for a given node id."""
+
         return [e.to_node for e in self._edges if e.from_node.node_id == node_id]
 
     @property
     def nodes(self):
         """Return all nodes in the graph."""
+
         return list(self._nodes.values())
 
     @property
     def edges(self):
         """Return all edges in the graph."""
+
         return self._edges
 
 
@@ -47,14 +55,17 @@ class XMLDataSourcePlugin(DataSourcePlugin):
 
     def name(self) -> str:
         """Return the human-readable name of the plugin."""
+
         return "XML Data Source Plugin"
 
     def identifier(self) -> str:
         """Return the unique identifier of the plugin."""
+
         return "xml_datasource"
 
     def _create_node(self, elem) -> Optional[XMLNode]:
         """Create an XMLNode if the element has an 'id' attribute, otherwise None."""
+
         node_id = elem.attrib.get("id")
         if not node_id:
             return None
@@ -65,39 +76,51 @@ class XMLDataSourcePlugin(DataSourcePlugin):
             if not child.attrib and child.text and child.text.strip()
         }
 
+        values["id"] = node_id
+
         return XMLNode(node_id, values)
 
     def _create_edge(self, parent_id: Optional[str], elem, id_to_node: Dict[str, XMLNode]) -> Optional[XMLEdge]:
         """Create an XMLEdge if element has 'reference' attribute and both nodes exist."""
+
         if "reference" in elem.attrib and parent_id:
             ref_id = elem.attrib["reference"]
             if parent_id in id_to_node and ref_id in id_to_node:
                 return XMLEdge(id_to_node[parent_id], id_to_node[ref_id])
         return None
 
-    def _parse_element(
+    def _collect_nodes(self, elem, graph: XMLGraph, id_to_node: Dict[str, XMLNode]) -> None:
+        """First pass: collect all nodes."""
+
+        node = self._create_node(elem)
+        if node:
+            graph.add_node(node)
+            id_to_node[node.node_id] = node
+
+        for child in elem:
+            self._collect_nodes(child, graph, id_to_node)
+
+    def _collect_edges(
         self,
         elem,
         graph: XMLGraph,
         id_to_node: Dict[str, XMLNode],
         current_parent_id: Optional[str] = None,
     ) -> None:
-        """Recursively parse XML elements and populate the graph with nodes and edges."""
-        node = self._create_node(elem)
-        if node:
-            graph.add_node(node)
-            id_to_node[node.node_id] = node
-            current_parent_id = node.node_id
+        """Second pass: collect all edges."""
 
-        edge = self._create_edge(current_parent_id, elem, id_to_node)
+        node_id = elem.attrib.get("id", current_parent_id)
+
+        edge = self._create_edge(node_id, elem, id_to_node)
         if edge:
             graph.add_edge(edge)
 
         for child in elem:
-            self._parse_element(child, graph, id_to_node, current_parent_id)
+            self._collect_edges(child, graph, id_to_node, node_id)
 
     def load(self, **kwargs) -> Graph:
         """Load an XML file and convert it into a Graph."""
+
         file_path = kwargs.get("file_path")
         if not file_path:
             raise ValueError("file_path must be provided in kwargs")
@@ -108,6 +131,7 @@ class XMLDataSourcePlugin(DataSourcePlugin):
         graph = XMLGraph()
         id_to_node: Dict[str, XMLNode] = {}
 
-        self._parse_element(root, graph, id_to_node)
+        self._collect_nodes(root, graph, id_to_node)
+        self._collect_edges(root, graph, id_to_node)
 
         return graph

--- a/graph_explorer/uploads/cyclic_graph.xml
+++ b/graph_explorer/uploads/cyclic_graph.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='utf-8'?>
+<People>
+    <Person id="1">
+        <FirstName>Grace</FirstName>
+        <LastName>Davis</LastName>
+        <Age>66</Age>
+        <City>Paris</City>
+        <Date>2025-12-12</Date>
+        <Friends>
+            <Friend reference="2" />
+        </Friends>
+    </Person>
+    <Person id="2">
+        <FirstName>Jack</FirstName>
+        <LastName>Smith</LastName>
+        <Age>68</Age>
+        <City>Madrid</City>
+        <Date>2025-03-03</Date>
+        <Friends>
+            <Friend reference="1" />
+        </Friends>
+    </Person>
+</People>

--- a/graph_explorer/uploads/people_graph.xml
+++ b/graph_explorer/uploads/people_graph.xml
@@ -1,2236 +1,2227 @@
 <?xml version='1.0' encoding='utf-8'?>
 <People>
-    <Person id="e35289b1-ad46-4b44-b34b-59fc5246a808">
-        <FirstName>Grace</FirstName>
-        <LastName>Davis</LastName>
-        <Age>66</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="fad1cc81-c784-4f12-973c-c01f70c8aeb3" />
-            <Friend reference="084e14f9-4f75-441c-a4c3-e21f6ecbb4af" />
-            <Friend reference="e9d03a1c-7173-40e5-a023-c7a1c610e3ea" />
-        </Friends>
-    </Person>
-    <Person id="5e6665d8-621e-4239-ab99-83a4171cbf37">
-        <FirstName>Jack</FirstName>
-        <LastName>Smith</LastName>
-        <Age>68</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="733b4fdf-7420-4e55-9006-a0db853afb53" />
-            <Friend reference="14921138-709b-421d-b4bd-300aa0f1a5eb" />
-            <Friend reference="2ea54c9b-c96d-4450-a8c2-b745d2f0ce75" />
-            <Friend reference="265ef9ee-9108-4332-9de3-ce837ab1ab79" />
-        </Friends>
-    </Person>
-    <Person id="9b0f80e0-d61d-477f-8774-338cec8363fa">
-        <FirstName>Alice</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>23</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="47dd4c47-da28-4c9c-81e4-c363dde507c3" />
-            <Friend reference="4eb57e1b-f0cd-4535-9b30-4f711df52897" />
-            <Friend reference="d1afacd2-2ddc-4bfc-afe0-d389bccd8ac8" />
-        </Friends>
-    </Person>
-    <Person id="255fcabe-b77a-4c2b-b98b-43cac3fc5cb0">
-        <FirstName>Eve</FirstName>
-        <LastName>Davis</LastName>
-        <Age>27</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="e8960626-93c8-4610-a68b-27710b8c57a5" />
-        </Friends>
-    </Person>
-    <Person id="116ee3ff-dde2-415d-b573-927cf83ca146">
-        <FirstName>Alice</FirstName>
-        <LastName>Smith</LastName>
-        <Age>60</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="4229ffc5-9a59-43bd-931a-d7715bb323de" />
-            <Friend reference="196d016c-ee46-4342-913e-fdb6084c733f" />
-            <Friend reference="ec88eb97-3472-41a5-b57b-facf2dc06236" />
-        </Friends>
-    </Person>
-    <Person id="47dd4c47-da28-4c9c-81e4-c363dde507c3">
-        <FirstName>Ivy</FirstName>
-        <LastName>Jones</LastName>
-        <Age>60</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="b7979061-e500-41ba-82ed-252a855aa449" />
-            <Friend reference="db43912a-fc76-4286-a017-479c11da344a" />
-            <Friend reference="5d10e3a7-5544-47d7-901a-a7e8c196784b" />
-            <Friend reference="4dea4278-b2f2-494d-b642-776ca344bba1" />
-            <Friend reference="8556f7fd-b6a6-402a-a333-62a9788caab5" />
-        </Friends>
-    </Person>
-    <Person id="ad4964fd-ac44-4613-9af1-55de566f7c39">
-        <FirstName>Ivy</FirstName>
-        <LastName>Miller</LastName>
-        <Age>72</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="245e3a7c-488f-4fa4-817f-4f75dd35efd8" />
-        </Friends>
-    </Person>
-    <Person id="50052d30-0320-4c70-a20f-8c6935956019">
-        <FirstName>Alice</FirstName>
-        <LastName>Johnson</LastName>
-        <Age>41</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="db43912a-fc76-4286-a017-479c11da344a" />
-            <Friend reference="8a29dd15-f5a8-4305-a2f2-3d69b58b7385" />
-            <Friend reference="4eb57e1b-f0cd-4535-9b30-4f711df52897" />
-            <Friend reference="f6509719-94b0-4b99-a164-1fe76a258c4e" />
-        </Friends>
-    </Person>
-    <Person id="7673123a-f1cd-408f-bbd9-9663588a5453">
-        <FirstName>Jack</FirstName>
-        <LastName>Brown</LastName>
-        <Age>64</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="373e8a4e-ec47-4855-8348-02a265737ba7" />
-            <Friend reference="0a07c6e5-f50b-4070-94ed-1192e57be736" />
-            <Friend reference="fefaf6df-9a04-4d3f-8daf-315288a12492" />
-        </Friends>
-    </Person>
-    <Person id="f2a5ae1d-731a-4e22-a097-62048fddde2a">
-        <FirstName>Grace</FirstName>
-        <LastName>Jones</LastName>
-        <Age>35</Age>
+    <Person id="0">
+        <FirstName>David</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>29</Age>
         <City>Berlin</City>
         <Friends>
-            <Friend reference="a1358452-5dee-4fa0-bc8b-bb956218d47d" />
-            <Friend reference="55fa2b5c-8e26-4f7a-b9e4-e003144cfb20" />
-            <Friend reference="2139f20d-b346-4518-9214-a235a041eb03" />
-            <Friend reference="e9d03a1c-7173-40e5-a023-c7a1c610e3ea" />
+            <Friend reference="43" />
+            <Friend reference="164" />
         </Friends>
     </Person>
-    <Person id="aebc1922-0238-4183-b046-43bf7e6f76ed">
-        <FirstName>Grace</FirstName>
-        <LastName>Williams</LastName>
-        <Age>49</Age>
-        <City>New York</City>
+    <Person id="1">
+        <FirstName>Steve</FirstName>
+        <LastName>Brown</LastName>
+        <Age>56</Age>
+        <City>Paris</City>
         <Friends>
-            <Friend reference="ca74c7b4-5285-4e16-babd-c224efd5f62e" />
-            <Friend reference="7673123a-f1cd-408f-bbd9-9663588a5453" />
-            <Friend reference="d57fb7f5-3eb5-4c12-b4b9-86e31390c7e4" />
-            <Friend reference="c26dda12-cf79-4f01-8a91-3c43229fa6d0" />
-            <Friend reference="d2ab86a8-2170-49ec-be6b-bf06de3da339" />
+            <Friend reference="132" />
+            <Friend reference="82" />
+            <Friend reference="160" />
+            <Friend reference="173" />
+            <Friend reference="161" />
         </Friends>
     </Person>
-    <Person id="bbd10667-0224-4e86-a89a-8e23dfc12ea9">
-        <FirstName>Jack</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>21</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="1145ca9b-02e5-4718-a8c1-90b433a624e0" />
-        </Friends>
-    </Person>
-    <Person id="14921138-709b-421d-b4bd-300aa0f1a5eb">
-        <FirstName>Frank</FirstName>
-        <LastName>Jones</LastName>
-        <Age>65</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="472ec1f0-d72a-4c7c-a951-2a6c51c60f25" />
-            <Friend reference="a1358452-5dee-4fa0-bc8b-bb956218d47d" />
-            <Friend reference="613a4c4e-02b2-4c8b-b2e2-3102471c54fb" />
-            <Friend reference="54f9ba76-d178-4064-b338-96765208669a" />
-        </Friends>
-    </Person>
-    <Person id="5597a848-377b-4db0-9466-91ed7ecacbb1">
-        <FirstName>Diana</FirstName>
-        <LastName>Davis</LastName>
-        <Age>46</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="9fd946b6-bebe-40ab-b5c6-f394e167eb89" />
-            <Friend reference="307ff5b2-a10d-42f1-b7a3-79274fb47669" />
-            <Friend reference="0e724252-57ba-4b24-9c4b-9016f7c0afac" />
-            <Friend reference="24b7a10f-7391-4d12-9e50-a81f8da6c8b1" />
-            <Friend reference="5974ddd5-4f85-49b5-8306-f77d281966ad" />
-        </Friends>
-    </Person>
-    <Person id="0b75944b-3bb8-4859-bfe9-c6969ee6087a">
-        <FirstName>Grace</FirstName>
-        <LastName>Johnson</LastName>
-        <Age>37</Age>
+    <Person id="2">
+        <FirstName>Martin</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>54</Age>
         <City>Tokyo</City>
         <Friends>
-            <Friend reference="a9532859-004e-42a9-96d4-384a139fd05d" />
-            <Friend reference="775badd5-73a2-4baa-8c8c-33932acb8d5e" />
-            <Friend reference="4a2e0855-9ed3-40a6-8938-9d297e233251" />
-            <Friend reference="0c955f29-a7b4-49ef-a795-e15ab53564ac" />
-            <Friend reference="1cfd5461-a8d8-48fc-bb89-e2ae31406334" />
+            <Friend reference="17" />
+            <Friend reference="181" />
+            <Friend reference="76" />
+            <Friend reference="157" />
         </Friends>
     </Person>
-    <Person id="a88f80d2-be27-45ba-874f-f99cc3670d79">
-        <FirstName>Eve</FirstName>
+    <Person id="3">
+        <FirstName>Ivy</FirstName>
+        <LastName>Smith</LastName>
+        <Age>64</Age>
+        <City>Paris</City>
+        <Friends>
+            <Friend reference="182" />
+            <Friend reference="190" />
+            <Friend reference="73" />
+        </Friends>
+    </Person>
+    <Person id="4">
+        <FirstName>Jack</FirstName>
+        <LastName>Williams</LastName>
+        <Age>73</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="15" />
+            <Friend reference="172" />
+            <Friend reference="123" />
+            <Friend reference="168" />
+            <Friend reference="120" />
+        </Friends>
+    </Person>
+    <Person id="5">
+        <FirstName>Diana</FirstName>
+        <LastName>Jones</LastName>
+        <Age>53</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="12" />
+            <Friend reference="114" />
+            <Friend reference="25" />
+            <Friend reference="172" />
+            <Friend reference="141" />
+        </Friends>
+    </Person>
+    <Person id="6">
+        <FirstName>Steve</FirstName>
         <LastName>Martinez</LastName>
-        <Age>61</Age>
+        <Age>41</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="39" />
+            <Friend reference="142" />
+            <Friend reference="179" />
+            <Friend reference="51" />
+            <Friend reference="22" />
+        </Friends>
+    </Person>
+    <Person id="7">
+        <FirstName>Bob</FirstName>
+        <LastName>Parker</LastName>
+        <Age>53</Age>
+        <City>Belgrade</City>
+        <Friends>
+            <Friend reference="61" />
+            <Friend reference="187" />
+        </Friends>
+    </Person>
+    <Person id="8">
+        <FirstName>Martin</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>18</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="35" />
+            <Friend reference="130" />
+            <Friend reference="124" />
+            <Friend reference="79" />
+        </Friends>
+    </Person>
+    <Person id="9">
+        <FirstName>Frank</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>34</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="14" />
+        </Friends>
+    </Person>
+    <Person id="10">
+        <FirstName>Frank</FirstName>
+        <LastName>Brown</LastName>
+        <Age>34</Age>
         <City>New York</City>
         <Friends>
-            <Friend reference="24b7a10f-7391-4d12-9e50-a81f8da6c8b1" />
-            <Friend reference="7bdbe39f-ffdc-409a-a671-899fce3ff56e" />
-            <Friend reference="0e8af981-99bf-400a-937e-55dfbe99fe3d" />
-            <Friend reference="925194d6-ff51-4afd-9faa-3b741543f803" />
+            <Friend reference="88" />
+            <Friend reference="143" />
+            <Friend reference="164" />
         </Friends>
     </Person>
-    <Person id="99028b3c-e796-4f50-83eb-dc3feebc2aeb">
+    <Person id="11">
+        <FirstName>Hank</FirstName>
+        <LastName>Smith</LastName>
+        <Age>71</Age>
+        <City>Paris</City>
+        <Friends>
+            <Friend reference="29" />
+            <Friend reference="143" />
+            <Friend reference="171" />
+        </Friends>
+    </Person>
+    <Person id="12">
+        <FirstName>Charlie</FirstName>
+        <LastName>Williams</LastName>
+        <Age>78</Age>
+        <City>Toronto</City>
+        <Friends>
+            <Friend reference="116" />
+            <Friend reference="146" />
+            <Friend reference="44" />
+            <Friend reference="148" />
+        </Friends>
+    </Person>
+    <Person id="13">
+        <FirstName>Ivy</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>75</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="77" />
+            <Friend reference="31" />
+        </Friends>
+    </Person>
+    <Person id="14">
+        <FirstName>Jack</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>76</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="102" />
+        </Friends>
+    </Person>
+    <Person id="15">
+        <FirstName>Grace</FirstName>
+        <LastName>Miller</LastName>
+        <Age>58</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="19" />
+            <Friend reference="194" />
+        </Friends>
+    </Person>
+    <Person id="16">
+        <FirstName>Eve</FirstName>
+        <LastName>Jones</LastName>
+        <Age>39</Age>
+        <City>Toronto</City>
+        <Friends>
+            <Friend reference="124" />
+            <Friend reference="76" />
+            <Friend reference="86" />
+        </Friends>
+    </Person>
+    <Person id="17">
+        <FirstName>Frank</FirstName>
+        <LastName>Wilson</LastName>
+        <Age>55</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="137" />
+            <Friend reference="55" />
+            <Friend reference="150" />
+            <Friend reference="194" />
+        </Friends>
+    </Person>
+    <Person id="18">
+        <FirstName>Angela</FirstName>
+        <LastName>Brown</LastName>
+        <Age>20</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="14" />
+            <Friend reference="8" />
+            <Friend reference="2" />
+            <Friend reference="66" />
+            <Friend reference="47" />
+        </Friends>
+    </Person>
+    <Person id="19">
+        <FirstName>Ivy</FirstName>
+        <LastName>Wilson</LastName>
+        <Age>78</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="186" />
+        </Friends>
+    </Person>
+    <Person id="20">
+        <FirstName>Angela</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>71</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="73" />
+            <Friend reference="91" />
+            <Friend reference="40" />
+            <Friend reference="124" />
+        </Friends>
+    </Person>
+    <Person id="21">
+        <FirstName>Jack</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>77</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="140" />
+            <Friend reference="109" />
+            <Friend reference="80" />
+        </Friends>
+    </Person>
+    <Person id="22">
+        <FirstName>Martin</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>77</Age>
+        <City>Belgrade</City>
+        <Friends>
+            <Friend reference="197" />
+        </Friends>
+    </Person>
+    <Person id="23">
+        <FirstName>Angela</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>79</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="121" />
+        </Friends>
+    </Person>
+    <Person id="24">
+        <FirstName>Frank</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>76</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="61" />
+            <Friend reference="186" />
+            <Friend reference="178" />
+            <Friend reference="47" />
+        </Friends>
+    </Person>
+    <Person id="25">
+        <FirstName>Martin</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>58</Age>
+        <City>New York</City>
+        <Friends>
+            <Friend reference="163" />
+            <Friend reference="110" />
+            <Friend reference="171" />
+            <Friend reference="27" />
+        </Friends>
+    </Person>
+    <Person id="26">
+        <FirstName>Jack</FirstName>
+        <LastName>Davis</LastName>
+        <Age>72</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="21" />
+            <Friend reference="61" />
+            <Friend reference="84" />
+            <Friend reference="48" />
+            <Friend reference="75" />
+        </Friends>
+    </Person>
+    <Person id="27">
+        <FirstName>Steve</FirstName>
+        <LastName>Davis</LastName>
+        <Age>63</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="107" />
+            <Friend reference="161" />
+            <Friend reference="176" />
+        </Friends>
+    </Person>
+    <Person id="28">
+        <FirstName>Charlie</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>32</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="135" />
+            <Friend reference="195" />
+        </Friends>
+    </Person>
+    <Person id="29">
+        <FirstName>Alice</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>38</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="39" />
+            <Friend reference="16" />
+        </Friends>
+    </Person>
+    <Person id="30">
+        <FirstName>Martin</FirstName>
+        <LastName>Smith</LastName>
+        <Age>21</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="77" />
+            <Friend reference="76" />
+            <Friend reference="57" />
+            <Friend reference="188" />
+            <Friend reference="151" />
+        </Friends>
+    </Person>
+    <Person id="31">
+        <FirstName>Alice</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>23</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="169" />
+            <Friend reference="161" />
+            <Friend reference="48" />
+            <Friend reference="105" />
+        </Friends>
+    </Person>
+    <Person id="32">
+        <FirstName>Jack</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>47</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="18" />
+            <Friend reference="125" />
+            <Friend reference="113" />
+            <Friend reference="144" />
+            <Friend reference="80" />
+        </Friends>
+    </Person>
+    <Person id="33">
+        <FirstName>Eve</FirstName>
+        <LastName>Parker</LastName>
+        <Age>55</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="145" />
+            <Friend reference="195" />
+            <Friend reference="66" />
+        </Friends>
+    </Person>
+    <Person id="34">
+        <FirstName>Steve</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>29</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="22" />
+        </Friends>
+    </Person>
+    <Person id="35">
+        <FirstName>Ivy</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>50</Age>
+        <City>Toronto</City>
+        <Friends>
+            <Friend reference="136" />
+            <Friend reference="125" />
+            <Friend reference="84" />
+            <Friend reference="83" />
+            <Friend reference="23" />
+        </Friends>
+    </Person>
+    <Person id="36">
+        <FirstName>Grace</FirstName>
+        <LastName>Jones</LastName>
+        <Age>59</Age>
+        <City>Belgrade</City>
+        <Friends>
+            <Friend reference="81" />
+            <Friend reference="19" />
+            <Friend reference="75" />
+            <Friend reference="96" />
+        </Friends>
+    </Person>
+    <Person id="37">
+        <FirstName>Bob</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>47</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="134" />
+        </Friends>
+    </Person>
+    <Person id="38">
+        <FirstName>Eve</FirstName>
+        <LastName>Brown</LastName>
+        <Age>49</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="116" />
+        </Friends>
+    </Person>
+    <Person id="39">
+        <FirstName>Grace</FirstName>
+        <LastName>Davis</LastName>
+        <Age>21</Age>
+        <City>Toronto</City>
+        <Friends>
+            <Friend reference="64" />
+        </Friends>
+    </Person>
+    <Person id="40">
+        <FirstName>Hank</FirstName>
+        <LastName>Smith</LastName>
+        <Age>50</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="3" />
+            <Friend reference="79" />
+            <Friend reference="123" />
+        </Friends>
+    </Person>
+    <Person id="41">
+        <FirstName>Steve</FirstName>
+        <LastName>Davis</LastName>
+        <Age>18</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="150" />
+            <Friend reference="33" />
+        </Friends>
+    </Person>
+    <Person id="42">
+        <FirstName>David</FirstName>
+        <LastName>Brown</LastName>
+        <Age>66</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="19" />
+            <Friend reference="96" />
+            <Friend reference="136" />
+        </Friends>
+    </Person>
+    <Person id="43">
+        <FirstName>Eve</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>25</Age>
+        <City>Paris</City>
+        <Friends>
+            <Friend reference="72" />
+            <Friend reference="41" />
+        </Friends>
+    </Person>
+    <Person id="44">
+        <FirstName>Frank</FirstName>
+        <LastName>Parker</LastName>
+        <Age>67</Age>
+        <City>Paris</City>
+        <Friends>
+            <Friend reference="194" />
+        </Friends>
+    </Person>
+    <Person id="45">
+        <FirstName>Angela</FirstName>
+        <LastName>Smith</LastName>
+        <Age>20</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="14" />
+            <Friend reference="87" />
+            <Friend reference="77" />
+            <Friend reference="113" />
+            <Friend reference="160" />
+        </Friends>
+    </Person>
+    <Person id="46">
         <FirstName>Alice</FirstName>
         <LastName>Jones</LastName>
+        <Age>55</Age>
+        <City>Washington</City>
+        <Friends>
+            <Friend reference="145" />
+            <Friend reference="4" />
+            <Friend reference="140" />
+            <Friend reference="57" />
+            <Friend reference="69" />
+        </Friends>
+    </Person>
+    <Person id="47">
+        <FirstName>Steve</FirstName>
+        <LastName>Davis</LastName>
         <Age>61</Age>
         <City>Toronto</City>
         <Friends>
-            <Friend reference="121aae50-6caa-4759-9b65-b3a0f549630a" />
-            <Friend reference="d57fb7f5-3eb5-4c12-b4b9-86e31390c7e4" />
-            <Friend reference="7f1bcea1-20be-44a6-80ed-81a6018a6bf6" />
+            <Friend reference="181" />
+            <Friend reference="109" />
+            <Friend reference="20" />
         </Friends>
     </Person>
-    <Person id="28bffb13-dc29-4d94-a996-42e5ffb929a7">
+    <Person id="48">
+        <FirstName>Grace</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>29</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="2" />
+            <Friend reference="142" />
+        </Friends>
+    </Person>
+    <Person id="49">
+        <FirstName>David</FirstName>
+        <LastName>Jones</LastName>
+        <Age>30</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="146" />
+            <Friend reference="51" />
+            <Friend reference="78" />
+        </Friends>
+    </Person>
+    <Person id="50">
+        <FirstName>Eve</FirstName>
+        <LastName>Wilson</LastName>
+        <Age>75</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="112" />
+            <Friend reference="58" />
+            <Friend reference="95" />
+            <Friend reference="190" />
+            <Friend reference="128" />
+        </Friends>
+    </Person>
+    <Person id="51">
+        <FirstName>Angela</FirstName>
+        <LastName>Wilson</LastName>
+        <Age>52</Age>
+        <City>Belgrade</City>
+        <Friends>
+            <Friend reference="107" />
+            <Friend reference="80" />
+            <Friend reference="46" />
+        </Friends>
+    </Person>
+    <Person id="52">
         <FirstName>Charlie</FirstName>
-        <LastName>Smith</LastName>
+        <LastName>Jones</LastName>
+        <Age>28</Age>
+        <City>New York</City>
+        <Friends>
+            <Friend reference="3" />
+        </Friends>
+    </Person>
+    <Person id="53">
+        <FirstName>Alice</FirstName>
+        <LastName>Williams</LastName>
+        <Age>28</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="171" />
+            <Friend reference="57" />
+            <Friend reference="34" />
+            <Friend reference="45" />
+            <Friend reference="182" />
+        </Friends>
+    </Person>
+    <Person id="54">
+        <FirstName>Eve</FirstName>
+        <LastName>Jones</LastName>
+        <Age>29</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="6" />
+            <Friend reference="158" />
+            <Friend reference="199" />
+            <Friend reference="2" />
+        </Friends>
+    </Person>
+    <Person id="55">
+        <FirstName>Steve</FirstName>
+        <LastName>Brown</LastName>
+        <Age>49</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="173" />
+            <Friend reference="75" />
+            <Friend reference="36" />
+            <Friend reference="51" />
+        </Friends>
+    </Person>
+    <Person id="56">
+        <FirstName>Bob</FirstName>
+        <LastName>Williams</LastName>
         <Age>55</Age>
         <City>Rome</City>
         <Friends>
-            <Friend reference="47dd4c47-da28-4c9c-81e4-c363dde507c3" />
-            <Friend reference="e8960626-93c8-4610-a68b-27710b8c57a5" />
-            <Friend reference="11a4ee19-6ab8-47d4-83b7-2802770f5fb7" />
-            <Friend reference="4229ffc5-9a59-43bd-931a-d7715bb323de" />
+            <Friend reference="69" />
+            <Friend reference="125" />
+            <Friend reference="194" />
+            <Friend reference="142" />
+            <Friend reference="173" />
         </Friends>
     </Person>
-    <Person id="0bd509b0-5ff7-4611-b0c0-ab18c7f2fb12">
-        <FirstName>Bob</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>49</Age>
-        <City>Toronto</City>
-        <Friends>
-            <Friend reference="6881d8fd-db6d-49e0-baa6-2fe6ab9ecd80" />
-            <Friend reference="81b1fed4-ed60-44fc-a985-ad0321cbd648" />
-            <Friend reference="e35289b1-ad46-4b44-b34b-59fc5246a808" />
-        </Friends>
-    </Person>
-    <Person id="ec88eb97-3472-41a5-b57b-facf2dc06236">
-        <FirstName>Bob</FirstName>
-        <LastName>Jones</LastName>
-        <Age>76</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="248b4feb-2a86-4e90-b1ed-6932550e9b54" />
-            <Friend reference="9017d323-0a52-443d-a966-bb4cfd391927" />
-            <Friend reference="a47307ef-a06b-45b2-8473-16070826bfe5" />
-            <Friend reference="d2ab86a8-2170-49ec-be6b-bf06de3da339" />
-            <Friend reference="9fd946b6-bebe-40ab-b5c6-f394e167eb89" />
-        </Friends>
-    </Person>
-    <Person id="25f00dbf-bae2-4c23-a43d-12a97337a354">
-        <FirstName>Frank</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>42</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="99028b3c-e796-4f50-83eb-dc3feebc2aeb" />
-        </Friends>
-    </Person>
-    <Person id="055dc5f6-5a4a-4a8c-888a-d39745b8c87c">
+    <Person id="57">
         <FirstName>Eve</FirstName>
-        <LastName>Davis</LastName>
-        <Age>76</Age>
-        <City>Madrid</City>
+        <LastName>Parker</LastName>
+        <Age>74</Age>
+        <City>Belgrade</City>
         <Friends>
-            <Friend reference="50052d30-0320-4c70-a20f-8c6935956019" />
-            <Friend reference="265ef9ee-9108-4332-9de3-ce837ab1ab79" />
+            <Friend reference="94" />
+            <Friend reference="3" />
+            <Friend reference="183" />
+            <Friend reference="137" />
+            <Friend reference="15" />
         </Friends>
     </Person>
-    <Person id="78c8043b-2aa8-4ea7-a5db-bc978f1d5804">
+    <Person id="58">
+        <FirstName>Bob</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>37</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="192" />
+            <Friend reference="155" />
+            <Friend reference="187" />
+        </Friends>
+    </Person>
+    <Person id="59">
+        <FirstName>Charlie</FirstName>
+        <LastName>Brown</LastName>
+        <Age>22</Age>
+        <City>Belgrade</City>
+        <Friends>
+            <Friend reference="196" />
+            <Friend reference="12" />
+        </Friends>
+    </Person>
+    <Person id="60">
         <FirstName>Alice</FirstName>
-        <LastName>Williams</LastName>
-        <Age>52</Age>
+        <LastName>Garcia</LastName>
+        <Age>37</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="110" />
+            <Friend reference="186" />
+            <Friend reference="81" />
+            <Friend reference="39" />
+            <Friend reference="49" />
+        </Friends>
+    </Person>
+    <Person id="61">
+        <FirstName>Frank</FirstName>
+        <LastName>Smith</LastName>
+        <Age>74</Age>
         <City>London</City>
         <Friends>
-            <Friend reference="515b1f72-c812-4bf8-9db5-16cce515a096" />
-            <Friend reference="613a4c4e-02b2-4c8b-b2e2-3102471c54fb" />
+            <Friend reference="127" />
+            <Friend reference="83" />
+            <Friend reference="69" />
+            <Friend reference="2" />
         </Friends>
     </Person>
-    <Person id="5e8f225a-4430-4230-b53f-a4106f659bbb">
-        <FirstName>Grace</FirstName>
-        <LastName>Johnson</LastName>
+    <Person id="62">
+        <FirstName>Ivy</FirstName>
+        <LastName>Parker</LastName>
         <Age>56</Age>
         <City>Madrid</City>
         <Friends>
-            <Friend reference="e9d03a1c-7173-40e5-a023-c7a1c610e3ea" />
-            <Friend reference="52d4d91e-6c14-4c34-a537-2d26e2c2a3e5" />
-            <Friend reference="a47c22d1-6279-475e-869b-8b9c644ab099" />
+            <Friend reference="129" />
         </Friends>
     </Person>
-    <Person id="99c66ce6-0fde-4b46-8f68-5de0d9f43251">
-        <FirstName>Eve</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>79</Age>
-        <City>Belgrade</City>
+    <Person id="63">
+        <FirstName>David</FirstName>
+        <LastName>Parker</LastName>
+        <Age>50</Age>
+        <City>Madrid</City>
         <Friends>
-            <Friend reference="91e3a072-2875-4075-8f99-476e084bd0b8" />
-            <Friend reference="925194d6-ff51-4afd-9faa-3b741543f803" />
-            <Friend reference="7bdbe39f-ffdc-409a-a671-899fce3ff56e" />
-            <Friend reference="26512242-d99a-4715-9dbe-b2ddbf8696e8" />
-            <Friend reference="93827627-b25b-4514-a9c7-dbaa8a0b0120" />
+            <Friend reference="149" />
+            <Friend reference="114" />
+            <Friend reference="122" />
+            <Friend reference="95" />
+            <Friend reference="109" />
         </Friends>
     </Person>
-    <Person id="726ca190-bdb2-45c9-b70f-6625f29dc482">
+    <Person id="64">
         <FirstName>Diana</FirstName>
-        <LastName>Brown</LastName>
-        <Age>79</Age>
-        <City>Tokyo</City>
+        <LastName>Parker</LastName>
+        <Age>23</Age>
+        <City>Ohio</City>
         <Friends>
-            <Friend reference="613a4c4e-02b2-4c8b-b2e2-3102471c54fb" />
+            <Friend reference="124" />
+            <Friend reference="104" />
         </Friends>
     </Person>
-    <Person id="1c8e478d-53b0-4aec-974b-e670a5cd2019">
+    <Person id="65">
+        <FirstName>Eve</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>27</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="136" />
+            <Friend reference="121" />
+            <Friend reference="67" />
+            <Friend reference="119" />
+        </Friends>
+    </Person>
+    <Person id="66">
+        <FirstName>David</FirstName>
+        <LastName>Wilson</LastName>
+        <Age>27</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="17" />
+        </Friends>
+    </Person>
+    <Person id="67">
+        <FirstName>Diana</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>51</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="106" />
+        </Friends>
+    </Person>
+    <Person id="68">
+        <FirstName>Grace</FirstName>
+        <LastName>Williams</LastName>
+        <Age>49</Age>
+        <City>New York</City>
+        <Friends>
+            <Friend reference="133" />
+            <Friend reference="145" />
+            <Friend reference="151" />
+            <Friend reference="163" />
+        </Friends>
+    </Person>
+    <Person id="69">
+        <FirstName>Bob</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>36</Age>
+        <City>Toronto</City>
+        <Friends>
+            <Friend reference="54" />
+            <Friend reference="38" />
+        </Friends>
+    </Person>
+    <Person id="70">
+        <FirstName>Alice</FirstName>
+        <LastName>Wilson</LastName>
+        <Age>52</Age>
+        <City>New York</City>
+        <Friends>
+            <Friend reference="50" />
+            <Friend reference="130" />
+            <Friend reference="122" />
+            <Friend reference="66" />
+        </Friends>
+    </Person>
+    <Person id="71">
+        <FirstName>Alice</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>51</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="48" />
+            <Friend reference="88" />
+            <Friend reference="105" />
+            <Friend reference="19" />
+            <Friend reference="73" />
+        </Friends>
+    </Person>
+    <Person id="72">
+        <FirstName>Charlie</FirstName>
+        <LastName>Parker</LastName>
+        <Age>67</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="25" />
+            <Friend reference="97" />
+            <Friend reference="117" />
+            <Friend reference="82" />
+            <Friend reference="51" />
+        </Friends>
+    </Person>
+    <Person id="73">
         <FirstName>Jack</FirstName>
-        <LastName>Brown</LastName>
-        <Age>40</Age>
-        <City>Tokyo</City>
+        <LastName>Parker</LastName>
+        <Age>69</Age>
+        <City>Berlin</City>
         <Friends>
-            <Friend reference="25f00dbf-bae2-4c23-a43d-12a97337a354" />
-            <Friend reference="67b9c4bb-60ba-41c4-adeb-8d148b8527a1" />
+            <Friend reference="93" />
+            <Friend reference="23" />
+            <Friend reference="101" />
         </Friends>
     </Person>
-    <Person id="613a4c4e-02b2-4c8b-b2e2-3102471c54fb">
-        <FirstName>Hank</FirstName>
-        <LastName>Miller</LastName>
-        <Age>43</Age>
+    <Person id="74">
+        <FirstName>Angela</FirstName>
+        <LastName>Williams</LastName>
+        <Age>71</Age>
         <City>Belgrade</City>
         <Friends>
-            <Friend reference="0bd509b0-5ff7-4611-b0c0-ab18c7f2fb12" />
-            <Friend reference="335d7a0a-dcb6-41d9-b75c-e6f54a32da71" />
-            <Friend reference="ab5d5185-aec8-4d66-9ba1-2474b42e1256" />
+            <Friend reference="121" />
+            <Friend reference="29" />
+            <Friend reference="34" />
+            <Friend reference="18" />
         </Friends>
     </Person>
-    <Person id="53db431c-761f-4007-b4af-e75325c540dd">
-        <FirstName>Grace</FirstName>
+    <Person id="75">
+        <FirstName>Steve</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>28</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="26" />
+            <Friend reference="53" />
+            <Friend reference="85" />
+            <Friend reference="144" />
+            <Friend reference="28" />
+        </Friends>
+    </Person>
+    <Person id="76">
+        <FirstName>Hank</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>61</Age>
+        <City>Washington</City>
+        <Friends>
+            <Friend reference="111" />
+            <Friend reference="142" />
+            <Friend reference="177" />
+            <Friend reference="184" />
+        </Friends>
+    </Person>
+    <Person id="77">
+        <FirstName>Angela</FirstName>
+        <LastName>Davis</LastName>
+        <Age>47</Age>
+        <City>Washington</City>
+        <Friends>
+            <Friend reference="171" />
+            <Friend reference="180" />
+            <Friend reference="124" />
+            <Friend reference="27" />
+            <Friend reference="198" />
+        </Friends>
+    </Person>
+    <Person id="78">
+        <FirstName>Eve</FirstName>
+        <LastName>Brown</LastName>
+        <Age>63</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="58" />
+            <Friend reference="115" />
+            <Friend reference="90" />
+            <Friend reference="128" />
+            <Friend reference="120" />
+        </Friends>
+    </Person>
+    <Person id="79">
+        <FirstName>Alice</FirstName>
+        <LastName>Davis</LastName>
+        <Age>31</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="133" />
+            <Friend reference="6" />
+            <Friend reference="152" />
+            <Friend reference="35" />
+        </Friends>
+    </Person>
+    <Person id="80">
+        <FirstName>Charlie</FirstName>
         <LastName>Jones</LastName>
-        <Age>23</Age>
+        <Age>78</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="144" />
+            <Friend reference="43" />
+            <Friend reference="6" />
+            <Friend reference="96" />
+            <Friend reference="161" />
+        </Friends>
+    </Person>
+    <Person id="81">
+        <FirstName>David</FirstName>
+        <LastName>Brown</LastName>
+        <Age>24</Age>
+        <City>New York</City>
+        <Friends>
+            <Friend reference="116" />
+            <Friend reference="121" />
+        </Friends>
+    </Person>
+    <Person id="82">
+        <FirstName>Frank</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>62</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="78" />
+            <Friend reference="26" />
+            <Friend reference="71" />
+            <Friend reference="122" />
+        </Friends>
+    </Person>
+    <Person id="83">
+        <FirstName>Hank</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>24</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="192" />
+            <Friend reference="99" />
+            <Friend reference="124" />
+        </Friends>
+    </Person>
+    <Person id="84">
+        <FirstName>David</FirstName>
+        <LastName>Parker</LastName>
+        <Age>58</Age>
+        <City>Toronto</City>
+        <Friends>
+            <Friend reference="26" />
+            <Friend reference="163" />
+            <Friend reference="77" />
+            <Friend reference="71" />
+        </Friends>
+    </Person>
+    <Person id="85">
+        <FirstName>Bob</FirstName>
+        <LastName>Miller</LastName>
+        <Age>54</Age>
+        <City>Belgrade</City>
+        <Friends>
+            <Friend reference="127" />
+            <Friend reference="33" />
+            <Friend reference="191" />
+            <Friend reference="77" />
+            <Friend reference="160" />
+        </Friends>
+    </Person>
+    <Person id="86">
+        <FirstName>Eve</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>19</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="26" />
+            <Friend reference="33" />
+            <Friend reference="69" />
+        </Friends>
+    </Person>
+    <Person id="87">
+        <FirstName>Frank</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>57</Age>
+        <City>New York</City>
+        <Friends>
+            <Friend reference="65" />
+            <Friend reference="184" />
+        </Friends>
+    </Person>
+    <Person id="88">
+        <FirstName>Grace</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>75</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="40" />
+            <Friend reference="149" />
+            <Friend reference="95" />
+            <Friend reference="56" />
+            <Friend reference="12" />
+        </Friends>
+    </Person>
+    <Person id="89">
+        <FirstName>Eve</FirstName>
+        <LastName>Wilson</LastName>
+        <Age>46</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="157" />
+            <Friend reference="67" />
+            <Friend reference="51" />
+            <Friend reference="184" />
+            <Friend reference="106" />
+        </Friends>
+    </Person>
+    <Person id="90">
+        <FirstName>Grace</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>24</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="58" />
+            <Friend reference="27" />
+            <Friend reference="64" />
+        </Friends>
+    </Person>
+    <Person id="91">
+        <FirstName>Alice</FirstName>
+        <LastName>Williams</LastName>
+        <Age>55</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="198" />
+        </Friends>
+    </Person>
+    <Person id="92">
+        <FirstName>Martin</FirstName>
+        <LastName>Miller</LastName>
+        <Age>24</Age>
+        <City>Belgrade</City>
+        <Friends>
+            <Friend reference="32" />
+            <Friend reference="48" />
+        </Friends>
+    </Person>
+    <Person id="93">
+        <FirstName>Hank</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>41</Age>
+        <City>Belgrade</City>
+        <Friends>
+            <Friend reference="135" />
+            <Friend reference="113" />
+            <Friend reference="158" />
+            <Friend reference="170" />
+            <Friend reference="68" />
+        </Friends>
+    </Person>
+    <Person id="94">
+        <FirstName>Alice</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>51</Age>
+        <City>Washington</City>
+        <Friends>
+            <Friend reference="78" />
+        </Friends>
+    </Person>
+    <Person id="95">
+        <FirstName>Eve</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>28</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="108" />
+            <Friend reference="195" />
+            <Friend reference="26" />
+        </Friends>
+    </Person>
+    <Person id="96">
+        <FirstName>Martin</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>54</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="13" />
+            <Friend reference="92" />
+            <Friend reference="39" />
+            <Friend reference="173" />
+        </Friends>
+    </Person>
+    <Person id="97">
+        <FirstName>Angela</FirstName>
+        <LastName>Brown</LastName>
+        <Age>26</Age>
+        <City>Paris</City>
+        <Friends>
+            <Friend reference="171" />
+            <Friend reference="139" />
+            <Friend reference="87" />
+        </Friends>
+    </Person>
+    <Person id="98">
+        <FirstName>Grace</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>61</Age>
+        <City>Paris</City>
+        <Friends>
+            <Friend reference="106" />
+            <Friend reference="180" />
+            <Friend reference="11" />
+        </Friends>
+    </Person>
+    <Person id="99">
+        <FirstName>Bob</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>37</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="30" />
+        </Friends>
+    </Person>
+    <Person id="100">
+        <FirstName>Bob</FirstName>
+        <LastName>Jones</LastName>
+        <Age>42</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="72" />
+            <Friend reference="81" />
+            <Friend reference="150" />
+            <Friend reference="16" />
+        </Friends>
+    </Person>
+    <Person id="101">
+        <FirstName>Angela</FirstName>
+        <LastName>Brown</LastName>
+        <Age>24</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="69" />
+        </Friends>
+    </Person>
+    <Person id="102">
+        <FirstName>Charlie</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>38</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="194" />
+            <Friend reference="86" />
+            <Friend reference="109" />
+            <Friend reference="160" />
+            <Friend reference="174" />
+        </Friends>
+    </Person>
+    <Person id="103">
+        <FirstName>Alice</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>26</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="198" />
+            <Friend reference="153" />
+            <Friend reference="184" />
+        </Friends>
+    </Person>
+    <Person id="104">
+        <FirstName>Alice</FirstName>
+        <LastName>Williams</LastName>
+        <Age>36</Age>
+        <City>New York</City>
+        <Friends>
+            <Friend reference="199" />
+            <Friend reference="43" />
+            <Friend reference="179" />
+            <Friend reference="181" />
+            <Friend reference="2" />
+        </Friends>
+    </Person>
+    <Person id="105">
+        <FirstName>Ivy</FirstName>
+        <LastName>Davis</LastName>
+        <Age>45</Age>
+        <City>Belgrade</City>
+        <Friends>
+            <Friend reference="14" />
+            <Friend reference="86" />
+            <Friend reference="92" />
+            <Friend reference="168" />
+            <Friend reference="59" />
+        </Friends>
+    </Person>
+    <Person id="106">
+        <FirstName>Eve</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>21</Age>
+        <City>New York</City>
+        <Friends>
+            <Friend reference="23" />
+            <Friend reference="12" />
+            <Friend reference="40" />
+            <Friend reference="88" />
+        </Friends>
+    </Person>
+    <Person id="107">
+        <FirstName>Angela</FirstName>
+        <LastName>Brown</LastName>
+        <Age>71</Age>
         <City>Sydney</City>
         <Friends>
-            <Friend reference="0b2c05d0-51d3-4db7-b01a-84bba52804f9" />
+            <Friend reference="150" />
+            <Friend reference="183" />
+            <Friend reference="152" />
+            <Friend reference="155" />
         </Friends>
     </Person>
-    <Person id="cd1c1970-5471-46d7-a3d0-2c858348976e">
-        <FirstName>Ivy</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>37</Age>
-        <City>Belgrade</City>
+    <Person id="108">
+        <FirstName>Alice</FirstName>
+        <LastName>Williams</LastName>
+        <Age>29</Age>
+        <City>Toronto</City>
         <Friends>
-            <Friend reference="121f74df-c016-43e0-abc6-b87a2757db5d" />
+            <Friend reference="94" />
+            <Friend reference="40" />
+            <Friend reference="168" />
+            <Friend reference="51" />
+            <Friend reference="8" />
         </Friends>
     </Person>
-    <Person id="df5339a5-6cab-498c-b7d6-540c7c73c72b">
+    <Person id="109">
+        <FirstName>Steve</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>27</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="49" />
+            <Friend reference="156" />
+            <Friend reference="171" />
+            <Friend reference="50" />
+        </Friends>
+    </Person>
+    <Person id="110">
+        <FirstName>Jack</FirstName>
+        <LastName>Davis</LastName>
+        <Age>63</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="157" />
+        </Friends>
+    </Person>
+    <Person id="111">
         <FirstName>Diana</FirstName>
+        <LastName>Wilson</LastName>
+        <Age>56</Age>
+        <City>Paris</City>
+        <Friends>
+            <Friend reference="164" />
+            <Friend reference="188" />
+            <Friend reference="16" />
+            <Friend reference="174" />
+            <Friend reference="115" />
+        </Friends>
+    </Person>
+    <Person id="112">
+        <FirstName>Grace</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>77</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="145" />
+            <Friend reference="103" />
+        </Friends>
+    </Person>
+    <Person id="113">
+        <FirstName>Bob</FirstName>
         <LastName>Jones</LastName>
+        <Age>69</Age>
+        <City>New York</City>
+        <Friends>
+            <Friend reference="57" />
+            <Friend reference="46" />
+            <Friend reference="134" />
+            <Friend reference="123" />
+            <Friend reference="18" />
+        </Friends>
+    </Person>
+    <Person id="114">
+        <FirstName>Steve</FirstName>
+        <LastName>Smith</LastName>
+        <Age>60</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="148" />
+            <Friend reference="9" />
+            <Friend reference="168" />
+            <Friend reference="178" />
+        </Friends>
+    </Person>
+    <Person id="115">
+        <FirstName>Grace</FirstName>
+        <LastName>Davis</LastName>
+        <Age>75</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="191" />
+            <Friend reference="89" />
+        </Friends>
+    </Person>
+    <Person id="116">
+        <FirstName>Alice</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>72</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="34" />
+            <Friend reference="36" />
+            <Friend reference="70" />
+            <Friend reference="94" />
+        </Friends>
+    </Person>
+    <Person id="117">
+        <FirstName>Bob</FirstName>
+        <LastName>Wilson</LastName>
+        <Age>71</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="84" />
+            <Friend reference="127" />
+        </Friends>
+    </Person>
+    <Person id="118">
+        <FirstName>Ivy</FirstName>
+        <LastName>Williams</LastName>
+        <Age>21</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="89" />
+        </Friends>
+    </Person>
+    <Person id="119">
+        <FirstName>Martin</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>64</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="43" />
+        </Friends>
+    </Person>
+    <Person id="120">
+        <FirstName>Steve</FirstName>
+        <LastName>Miller</LastName>
+        <Age>50</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="140" />
+            <Friend reference="179" />
+            <Friend reference="45" />
+        </Friends>
+    </Person>
+    <Person id="121">
+        <FirstName>Hank</FirstName>
+        <LastName>Williams</LastName>
+        <Age>30</Age>
+        <City>Toronto</City>
+        <Friends>
+            <Friend reference="143" />
+            <Friend reference="59" />
+        </Friends>
+    </Person>
+    <Person id="122">
+        <FirstName>Eve</FirstName>
+        <LastName>Smith</LastName>
+        <Age>53</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="157" />
+        </Friends>
+    </Person>
+    <Person id="123">
+        <FirstName>Angela</FirstName>
+        <LastName>Parker</LastName>
+        <Age>66</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="6" />
+        </Friends>
+    </Person>
+    <Person id="124">
+        <FirstName>Jack</FirstName>
+        <LastName>Smith</LastName>
+        <Age>48</Age>
+        <City>New York</City>
+        <Friends>
+            <Friend reference="174" />
+            <Friend reference="145" />
+        </Friends>
+    </Person>
+    <Person id="125">
+        <FirstName>Eve</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>28</Age>
+        <City>Washington</City>
+        <Friends>
+            <Friend reference="78" />
+            <Friend reference="59" />
+            <Friend reference="86" />
+            <Friend reference="111" />
+            <Friend reference="106" />
+        </Friends>
+    </Person>
+    <Person id="126">
+        <FirstName>Alice</FirstName>
+        <LastName>Miller</LastName>
+        <Age>55</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="175" />
+        </Friends>
+    </Person>
+    <Person id="127">
+        <FirstName>Martin</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>56</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="96" />
+            <Friend reference="159" />
+        </Friends>
+    </Person>
+    <Person id="128">
+        <FirstName>Jack</FirstName>
+        <LastName>Williams</LastName>
+        <Age>56</Age>
+        <City>Washington</City>
+        <Friends>
+            <Friend reference="47" />
+            <Friend reference="142" />
+            <Friend reference="35" />
+            <Friend reference="23" />
+        </Friends>
+    </Person>
+    <Person id="129">
+        <FirstName>Diana</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>39</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="136" />
+            <Friend reference="104" />
+            <Friend reference="12" />
+            <Friend reference="35" />
+        </Friends>
+    </Person>
+    <Person id="130">
+        <FirstName>Frank</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>61</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="175" />
+        </Friends>
+    </Person>
+    <Person id="131">
+        <FirstName>David</FirstName>
+        <LastName>Jones</LastName>
+        <Age>60</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="57" />
+            <Friend reference="127" />
+            <Friend reference="190" />
+            <Friend reference="49" />
+        </Friends>
+    </Person>
+    <Person id="132">
+        <FirstName>Hank</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>26</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="80" />
+            <Friend reference="179" />
+        </Friends>
+    </Person>
+    <Person id="133">
+        <FirstName>Eve</FirstName>
+        <LastName>Dickinson</LastName>
         <Age>67</Age>
         <City>Belgrade</City>
         <Friends>
-            <Friend reference="24b7a10f-7391-4d12-9e50-a81f8da6c8b1" />
-            <Friend reference="042ea171-71bd-4e0c-b669-ccc501b7089f" />
-            <Friend reference="cd464b11-884f-4ce9-b864-c449b5d90825" />
+            <Friend reference="113" />
+            <Friend reference="116" />
+            <Friend reference="102" />
+            <Friend reference="14" />
+            <Friend reference="181" />
         </Friends>
     </Person>
-    <Person id="1145ca9b-02e5-4718-a8c1-90b433a624e0">
-        <FirstName>Grace</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>41</Age>
-        <City>New York</City>
+    <Person id="134">
+        <FirstName>Angela</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>44</Age>
+        <City>Paris</City>
         <Friends>
-            <Friend reference="99c66ce6-0fde-4b46-8f68-5de0d9f43251" />
-            <Friend reference="3862037c-93a3-4fd9-8311-e73eba84d9d4" />
+            <Friend reference="75" />
         </Friends>
     </Person>
-    <Person id="7cf30bf3-a868-41c4-a072-ae33ba77c2ca">
-        <FirstName>Jack</FirstName>
-        <LastName>Brown</LastName>
-        <Age>49</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="99028b3c-e796-4f50-83eb-dc3feebc2aeb" />
-            <Friend reference="c2fb52c1-73d4-4c3f-8221-7e642747e282" />
-            <Friend reference="121aae50-6caa-4759-9b65-b3a0f549630a" />
-        </Friends>
-    </Person>
-    <Person id="38935bc8-4710-4457-af86-ea5b4a29f80e">
-        <FirstName>Frank</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>60</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="99028b3c-e796-4f50-83eb-dc3feebc2aeb" />
-            <Friend reference="db808525-3b9c-4040-abf9-f15b1f419808" />
-            <Friend reference="1cfd5461-a8d8-48fc-bb89-e2ae31406334" />
-            <Friend reference="93827627-b25b-4514-a9c7-dbaa8a0b0120" />
-        </Friends>
-    </Person>
-    <Person id="042ea171-71bd-4e0c-b669-ccc501b7089f">
+    <Person id="135">
         <FirstName>Frank</FirstName>
         <LastName>Miller</LastName>
-        <Age>42</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="a1358452-5dee-4fa0-bc8b-bb956218d47d" />
-            <Friend reference="8cfd0d48-cc44-43d4-af5a-7f9fda36c5d5" />
-            <Friend reference="ec88eb97-3472-41a5-b57b-facf2dc06236" />
-            <Friend reference="0c955f29-a7b4-49ef-a795-e15ab53564ac" />
-        </Friends>
-    </Person>
-    <Person id="723b7831-2d3e-49db-82bb-804cb52955ac">
-        <FirstName>Frank</FirstName>
-        <LastName>Brown</LastName>
-        <Age>65</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="bfa085a9-e3f1-434c-8dfa-d3adbc4463e6" />
-            <Friend reference="66eca3bd-665f-4cb3-92f1-ccab02a53d0a" />
-        </Friends>
-    </Person>
-    <Person id="15b7523e-388f-40af-ac33-31332ffd5f10">
-        <FirstName>Alice</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>26</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="14921138-709b-421d-b4bd-300aa0f1a5eb" />
-            <Friend reference="bbd10667-0224-4e86-a89a-8e23dfc12ea9" />
-            <Friend reference="b7979061-e500-41ba-82ed-252a855aa449" />
-            <Friend reference="1cfd5461-a8d8-48fc-bb89-e2ae31406334" />
-            <Friend reference="116ee3ff-dde2-415d-b573-927cf83ca146" />
-        </Friends>
-    </Person>
-    <Person id="b6207793-6a1f-467b-900d-1387f528fafb">
-        <FirstName>Frank</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>65</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="adf87840-0353-4fcc-be64-5b123b3af58b" />
-        </Friends>
-    </Person>
-    <Person id="52d4d91e-6c14-4c34-a537-2d26e2c2a3e5">
-        <FirstName>Frank</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>44</Age>
-        <City>Toronto</City>
-        <Friends>
-            <Friend reference="df5339a5-6cab-498c-b7d6-540c7c73c72b" />
-            <Friend reference="7db08737-7701-48a9-8a79-9b8c97eda088" />
-        </Friends>
-    </Person>
-    <Person id="9ac4ec64-f272-4652-bccb-f86b0b32e833">
-        <FirstName>Alice</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>62</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="aebc1922-0238-4183-b046-43bf7e6f76ed" />
-        </Friends>
-    </Person>
-    <Person id="b755e758-8ab3-4afc-91ec-4aa0bd8f2bf1">
-        <FirstName>Eve</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>59</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="e8960626-93c8-4610-a68b-27710b8c57a5" />
-            <Friend reference="5974ddd5-4f85-49b5-8306-f77d281966ad" />
-            <Friend reference="0aed9f46-bd40-482d-b1db-2025675f70f2" />
-            <Friend reference="0b2c05d0-51d3-4db7-b01a-84bba52804f9" />
-        </Friends>
-    </Person>
-    <Person id="5974ddd5-4f85-49b5-8306-f77d281966ad">
-        <FirstName>Charlie</FirstName>
-        <LastName>Jones</LastName>
         <Age>22</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="05af2781-6b3c-4e9b-8bd5-e427a2e0d2a6" />
-            <Friend reference="513257d5-140e-4d2d-89f7-237c8b025883" />
-            <Friend reference="7cf30bf3-a868-41c4-a072-ae33ba77c2ca" />
-            <Friend reference="50052d30-0320-4c70-a20f-8c6935956019" />
-            <Friend reference="e9d03a1c-7173-40e5-a023-c7a1c610e3ea" />
-        </Friends>
-    </Person>
-    <Person id="bcd6f508-669f-4cf4-87fb-a248f978df20">
-        <FirstName>Eve</FirstName>
-        <LastName>Smith</LastName>
-        <Age>34</Age>
         <City>Tokyo</City>
         <Friends>
-            <Friend reference="248b4feb-2a86-4e90-b1ed-6932550e9b54" />
-            <Friend reference="e6da0438-ec6c-49ff-bf57-3b72fecdded0" />
-            <Friend reference="5a361aa2-947b-4b8b-8127-2a5e1a5b8c91" />
+            <Friend reference="11" />
+            <Friend reference="77" />
+            <Friend reference="22" />
+            <Friend reference="112" />
         </Friends>
     </Person>
-    <Person id="373e8a4e-ec47-4855-8348-02a265737ba7">
-        <FirstName>Frank</FirstName>
-        <LastName>Brown</LastName>
-        <Age>72</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="5cc3d307-4b82-4cba-8203-c98a1c8dac47" />
-        </Friends>
-    </Person>
-    <Person id="298a8edf-8149-4a63-9266-13abcc15fe21">
-        <FirstName>Ivy</FirstName>
-        <LastName>Williams</LastName>
-        <Age>42</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="91e3a072-2875-4075-8f99-476e084bd0b8" />
-            <Friend reference="2819cf82-bf1a-4c73-aa7b-f4558644a4f8" />
-            <Friend reference="f6509719-94b0-4b99-a164-1fe76a258c4e" />
-            <Friend reference="55fa2b5c-8e26-4f7a-b9e4-e003144cfb20" />
-        </Friends>
-    </Person>
-    <Person id="650b05a1-b300-4ae6-8ce7-2494525d023b">
-        <FirstName>Frank</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>35</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="084e14f9-4f75-441c-a4c3-e21f6ecbb4af" />
-            <Friend reference="83441d1e-3751-45c7-826b-7bd615fdbaec" />
-            <Friend reference="4dea4278-b2f2-494d-b642-776ca344bba1" />
-        </Friends>
-    </Person>
-    <Person id="155c9358-eb9a-413c-80c8-550a716d53fb">
+    <Person id="136">
         <FirstName>Charlie</FirstName>
-        <LastName>Brown</LastName>
-        <Age>76</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="6881d8fd-db6d-49e0-baa6-2fe6ab9ecd80" />
-            <Friend reference="e8960626-93c8-4610-a68b-27710b8c57a5" />
-            <Friend reference="14921138-709b-421d-b4bd-300aa0f1a5eb" />
-            <Friend reference="b755e758-8ab3-4afc-91ec-4aa0bd8f2bf1" />
-            <Friend reference="084e14f9-4f75-441c-a4c3-e21f6ecbb4af" />
-        </Friends>
-    </Person>
-    <Person id="f42249fb-f473-4124-8d05-65edfda4edf9">
-        <FirstName>Bob</FirstName>
-        <LastName>Davis</LastName>
-        <Age>76</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="15b7523e-388f-40af-ac33-31332ffd5f10" />
-            <Friend reference="ebb01581-aea4-4ff8-bb00-4d1c673cc03a" />
-        </Friends>
-    </Person>
-    <Person id="121f74df-c016-43e0-abc6-b87a2757db5d">
-        <FirstName>Grace</FirstName>
-        <LastName>Jones</LastName>
-        <Age>68</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="b87a06ee-1e6d-4539-ae2d-c3fe2a7fe3fe" />
-            <Friend reference="055dc5f6-5a4a-4a8c-888a-d39745b8c87c" />
-        </Friends>
-    </Person>
-    <Person id="511ccf19-0453-4596-84ca-8c26c751718f">
-        <FirstName>Jack</FirstName>
-        <LastName>Williams</LastName>
-        <Age>69</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="f42249fb-f473-4124-8d05-65edfda4edf9" />
-        </Friends>
-    </Person>
-    <Person id="307ff5b2-a10d-42f1-b7a3-79274fb47669">
-        <FirstName>Alice</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>51</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="e00f1baf-370a-4c7e-ba18-ea6dad59da75" />
-            <Friend reference="50052d30-0320-4c70-a20f-8c6935956019" />
-        </Friends>
-    </Person>
-    <Person id="444a0dfa-24e1-4e5b-8e78-71545e8b7abd">
-        <FirstName>Charlie</FirstName>
-        <LastName>Jones</LastName>
-        <Age>64</Age>
-        <City>Toronto</City>
-        <Friends>
-            <Friend reference="8cfd0d48-cc44-43d4-af5a-7f9fda36c5d5" />
-            <Friend reference="ebb01581-aea4-4ff8-bb00-4d1c673cc03a" />
-            <Friend reference="0c955f29-a7b4-49ef-a795-e15ab53564ac" />
-            <Friend reference="e9d03a1c-7173-40e5-a023-c7a1c610e3ea" />
-        </Friends>
-    </Person>
-    <Person id="0c955f29-a7b4-49ef-a795-e15ab53564ac">
-        <FirstName>Frank</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>62</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="28bffb13-dc29-4d94-a996-42e5ffb929a7" />
-            <Friend reference="53db431c-761f-4007-b4af-e75325c540dd" />
-        </Friends>
-    </Person>
-    <Person id="ca74c7b4-5285-4e16-babd-c224efd5f62e">
-        <FirstName>Eve</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>51</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="15b7523e-388f-40af-ac33-31332ffd5f10" />
-            <Friend reference="f42249fb-f473-4124-8d05-65edfda4edf9" />
-            <Friend reference="54f9ba76-d178-4064-b338-96765208669a" />
-            <Friend reference="25f00dbf-bae2-4c23-a43d-12a97337a354" />
-            <Friend reference="dc6ee606-68ff-43c9-8801-f7239d76ca75" />
-        </Friends>
-    </Person>
-    <Person id="4f080671-134e-4470-94e3-fa0ff20c053b">
-        <FirstName>Jack</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>52</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="0b2c05d0-51d3-4db7-b01a-84bba52804f9" />
-        </Friends>
-    </Person>
-    <Person id="fae8379b-2b4b-4036-8a4c-2080145dbb82">
-        <FirstName>Hank</FirstName>
-        <LastName>Davis</LastName>
-        <Age>51</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="66eca3bd-665f-4cb3-92f1-ccab02a53d0a" />
-            <Friend reference="255fcabe-b77a-4c2b-b98b-43cac3fc5cb0" />
-            <Friend reference="1770a8ec-3368-4fca-81e1-71f26913b1f0" />
-            <Friend reference="a5d10382-c473-4565-a5a2-7eab5f71c7b5" />
-            <Friend reference="53db431c-761f-4007-b4af-e75325c540dd" />
-        </Friends>
-    </Person>
-    <Person id="4eec3876-ffad-4a3a-a931-3af9f6f2a68a">
-        <FirstName>Eve</FirstName>
         <LastName>Davis</LastName>
         <Age>40</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="2ea54c9b-c96d-4450-a8c2-b745d2f0ce75" />
-        </Friends>
-    </Person>
-    <Person id="79a7d514-2127-4865-9722-7a9d96ff9587">
-        <FirstName>Jack</FirstName>
-        <LastName>Jones</LastName>
-        <Age>78</Age>
         <City>Rome</City>
         <Friends>
-            <Friend reference="8e237aae-0d64-4c31-85eb-95a7eb3cdea4" />
-            <Friend reference="4eb57e1b-f0cd-4535-9b30-4f711df52897" />
-            <Friend reference="e35289b1-ad46-4b44-b34b-59fc5246a808" />
-            <Friend reference="5597a848-377b-4db0-9466-91ed7ecacbb1" />
+            <Friend reference="92" />
         </Friends>
     </Person>
-    <Person id="513257d5-140e-4d2d-89f7-237c8b025883">
-        <FirstName>Ivy</FirstName>
-        <LastName>Johnson</LastName>
+    <Person id="137">
+        <FirstName>David</FirstName>
+        <LastName>Williams</LastName>
         <Age>45</Age>
-        <City>Paris</City>
+        <City>Belgrade</City>
         <Friends>
-            <Friend reference="723b7831-2d3e-49db-82bb-804cb52955ac" />
-            <Friend reference="28bffb13-dc29-4d94-a996-42e5ffb929a7" />
-            <Friend reference="c5eddc20-1fba-4ea2-b220-83e3b23daf41" />
+            <Friend reference="152" />
+            <Friend reference="116" />
         </Friends>
     </Person>
-    <Person id="26512242-d99a-4715-9dbe-b2ddbf8696e8">
-        <FirstName>Jack</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>58</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="0c955f29-a7b4-49ef-a795-e15ab53564ac" />
-            <Friend reference="3862037c-93a3-4fd9-8311-e73eba84d9d4" />
-            <Friend reference="0e724252-57ba-4b24-9c4b-9016f7c0afac" />
-            <Friend reference="c20bda61-fa5f-4f12-b991-3e91a67e40bb" />
-            <Friend reference="db43912a-fc76-4286-a017-479c11da344a" />
-        </Friends>
-    </Person>
-    <Person id="c26dda12-cf79-4f01-8a91-3c43229fa6d0">
-        <FirstName>Bob</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>41</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="ec065f2c-aabe-462c-ac4d-aa923b63b87f" />
-        </Friends>
-    </Person>
-    <Person id="b95dd8df-3457-4b03-b486-ed39d125aa58">
-        <FirstName>Ivy</FirstName>
-        <LastName>Jones</LastName>
-        <Age>35</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="9017d323-0a52-443d-a966-bb4cfd391927" />
-            <Friend reference="ebb01581-aea4-4ff8-bb00-4d1c673cc03a" />
-            <Friend reference="25f00dbf-bae2-4c23-a43d-12a97337a354" />
-            <Friend reference="335d7a0a-dcb6-41d9-b75c-e6f54a32da71" />
-            <Friend reference="28bffb13-dc29-4d94-a996-42e5ffb929a7" />
-        </Friends>
-    </Person>
-    <Person id="c0d0ddb9-d7d3-4cae-a329-3a031a24a248">
+    <Person id="138">
         <FirstName>Eve</FirstName>
-        <LastName>Johnson</LastName>
+        <LastName>Jones</LastName>
+        <Age>74</Age>
+        <City>Toronto</City>
+        <Friends>
+            <Friend reference="45" />
+            <Friend reference="149" />
+            <Friend reference="97" />
+            <Friend reference="17" />
+        </Friends>
+    </Person>
+    <Person id="139">
+        <FirstName>Charlie</FirstName>
+        <LastName>Jones</LastName>
         <Age>53</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="85eed631-648d-449c-8b69-b5b4d63c52fb" />
-            <Friend reference="0e0d7f43-5cc5-414e-b272-9fad36aa1a0f" />
-            <Friend reference="56d3d1ae-5797-400b-945a-53ced7f20cf9" />
-        </Friends>
-    </Person>
-    <Person id="0b356a7e-5067-449b-a27a-68170233a6b4">
-        <FirstName>Eve</FirstName>
-        <LastName>Davis</LastName>
-        <Age>71</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="5597a848-377b-4db0-9466-91ed7ecacbb1" />
-            <Friend reference="e9d03a1c-7173-40e5-a023-c7a1c610e3ea" />
-            <Friend reference="4eb57e1b-f0cd-4535-9b30-4f711df52897" />
-            <Friend reference="cd1c1970-5471-46d7-a3d0-2c858348976e" />
-            <Friend reference="15b7523e-388f-40af-ac33-31332ffd5f10" />
-        </Friends>
-    </Person>
-    <Person id="121aae50-6caa-4759-9b65-b3a0f549630a">
-        <FirstName>Charlie</FirstName>
-        <LastName>Brown</LastName>
-        <Age>50</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="335d7a0a-dcb6-41d9-b75c-e6f54a32da71" />
-            <Friend reference="67b9c4bb-60ba-41c4-adeb-8d148b8527a1" />
-            <Friend reference="fefaf6df-9a04-4d3f-8daf-315288a12492" />
-            <Friend reference="f6509719-94b0-4b99-a164-1fe76a258c4e" />
-        </Friends>
-    </Person>
-    <Person id="8bc27905-d333-4e67-9ec5-64a36dfd3b19">
-        <FirstName>Hank</FirstName>
-        <LastName>Jones</LastName>
-        <Age>78</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="b10b954a-cf7f-4be2-ac5a-bea8824e7ca5" />
-            <Friend reference="db43912a-fc76-4286-a017-479c11da344a" />
-        </Friends>
-    </Person>
-    <Person id="4229ffc5-9a59-43bd-931a-d7715bb323de">
-        <FirstName>Alice</FirstName>
-        <LastName>Williams</LastName>
-        <Age>37</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="5e8f225a-4430-4230-b53f-a4106f659bbb" />
-            <Friend reference="b7979061-e500-41ba-82ed-252a855aa449" />
-            <Friend reference="4f080671-134e-4470-94e3-fa0ff20c053b" />
-            <Friend reference="9fd946b6-bebe-40ab-b5c6-f394e167eb89" />
-        </Friends>
-    </Person>
-    <Person id="adf87840-0353-4fcc-be64-5b123b3af58b">
-        <FirstName>Ivy</FirstName>
-        <LastName>Williams</LastName>
-        <Age>55</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="b95dd8df-3457-4b03-b486-ed39d125aa58" />
-            <Friend reference="7717505e-c0da-449c-8077-ff5e0fc31053" />
-            <Friend reference="00eb74b0-9258-4026-8ac7-155fed542770" />
-        </Friends>
-    </Person>
-    <Person id="2729c0c0-b625-45d1-a4e5-a00a77e38cf4">
-        <FirstName>Grace</FirstName>
-        <LastName>Jones</LastName>
-        <Age>74</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="a9d9b2cb-a849-4cf0-86d2-f579043c5f0b" />
-            <Friend reference="7fdd054b-8f61-4918-9370-a3051868ba73" />
-            <Friend reference="0bd509b0-5ff7-4611-b0c0-ab18c7f2fb12" />
-        </Friends>
-    </Person>
-    <Person id="0e724252-57ba-4b24-9c4b-9016f7c0afac">
-        <FirstName>Bob</FirstName>
-        <LastName>Brown</LastName>
-        <Age>80</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="307ff5b2-a10d-42f1-b7a3-79274fb47669" />
-            <Friend reference="81b1fed4-ed60-44fc-a985-ad0321cbd648" />
-            <Friend reference="85eed631-648d-449c-8b69-b5b4d63c52fb" />
-            <Friend reference="121f74df-c016-43e0-abc6-b87a2757db5d" />
-        </Friends>
-    </Person>
-    <Person id="7717505e-c0da-449c-8077-ff5e0fc31053">
-        <FirstName>Grace</FirstName>
-        <LastName>Brown</LastName>
-        <Age>55</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="7d3e3c2b-0324-416e-bf9b-90815d8aec90" />
-            <Friend reference="79a7d514-2127-4865-9722-7a9d96ff9587" />
-        </Friends>
-    </Person>
-    <Person id="8b02691d-e89c-4eb7-bad1-09b223cb8965">
-        <FirstName>Charlie</FirstName>
-        <LastName>Johnson</LastName>
-        <Age>33</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="2892a631-2ed3-4055-91ce-80d75de3b9fa" />
-            <Friend reference="b87a06ee-1e6d-4539-ae2d-c3fe2a7fe3fe" />
-            <Friend reference="bfa085a9-e3f1-434c-8dfa-d3adbc4463e6" />
-            <Friend reference="fad1cc81-c784-4f12-973c-c01f70c8aeb3" />
-            <Friend reference="26512242-d99a-4715-9dbe-b2ddbf8696e8" />
-        </Friends>
-    </Person>
-    <Person id="d7826fc5-4dbd-4fb4-a5c1-9e8b46344bd2">
-        <FirstName>Eve</FirstName>
-        <LastName>Miller</LastName>
-        <Age>72</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="8a29dd15-f5a8-4305-a2f2-3d69b58b7385" />
-            <Friend reference="ec065f2c-aabe-462c-ac4d-aa923b63b87f" />
-            <Friend reference="99c66ce6-0fde-4b46-8f68-5de0d9f43251" />
-            <Friend reference="53db431c-761f-4007-b4af-e75325c540dd" />
-            <Friend reference="11a4ee19-6ab8-47d4-83b7-2802770f5fb7" />
-        </Friends>
-    </Person>
-    <Person id="11a4ee19-6ab8-47d4-83b7-2802770f5fb7">
-        <FirstName>Frank</FirstName>
-        <LastName>Smith</LastName>
-        <Age>36</Age>
-        <City>Toronto</City>
-        <Friends>
-            <Friend reference="7717505e-c0da-449c-8077-ff5e0fc31053" />
-            <Friend reference="8556f7fd-b6a6-402a-a333-62a9788caab5" />
-            <Friend reference="52d4d91e-6c14-4c34-a537-2d26e2c2a3e5" />
-        </Friends>
-    </Person>
-    <Person id="196d016c-ee46-4342-913e-fdb6084c733f">
-        <FirstName>Hank</FirstName>
-        <LastName>Johnson</LastName>
-        <Age>75</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="e6517e81-1153-4e15-b3c2-0ed2866a3e01" />
-        </Friends>
-    </Person>
-    <Person id="8556f7fd-b6a6-402a-a333-62a9788caab5">
-        <FirstName>Charlie</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>47</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="9d2ce7c3-1276-4b7c-8a87-6b5ed60753da" />
-            <Friend reference="7cf30bf3-a868-41c4-a072-ae33ba77c2ca" />
-            <Friend reference="dc6ee606-68ff-43c9-8801-f7239d76ca75" />
-            <Friend reference="c0d0ddb9-d7d3-4cae-a329-3a031a24a248" />
-            <Friend reference="d57fb7f5-3eb5-4c12-b4b9-86e31390c7e4" />
-        </Friends>
-    </Person>
-    <Person id="a7b5ab4a-4084-49b4-b2ee-a71497a2bbba">
-        <FirstName>Grace</FirstName>
-        <LastName>Davis</LastName>
-        <Age>42</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="4eec3876-ffad-4a3a-a931-3af9f6f2a68a" />
-            <Friend reference="ab5d5185-aec8-4d66-9ba1-2474b42e1256" />
-            <Friend reference="2139f20d-b346-4518-9214-a235a041eb03" />
-            <Friend reference="38935bc8-4710-4457-af86-ea5b4a29f80e" />
-            <Friend reference="4dea4278-b2f2-494d-b642-776ca344bba1" />
-        </Friends>
-    </Person>
-    <Person id="8e237aae-0d64-4c31-85eb-95a7eb3cdea4">
-        <FirstName>Bob</FirstName>
-        <LastName>Williams</LastName>
-        <Age>26</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="4eec3876-ffad-4a3a-a931-3af9f6f2a68a" />
-            <Friend reference="91e3a072-2875-4075-8f99-476e084bd0b8" />
-            <Friend reference="444a0dfa-24e1-4e5b-8e78-71545e8b7abd" />
-            <Friend reference="0aed9f46-bd40-482d-b1db-2025675f70f2" />
-        </Friends>
-    </Person>
-    <Person id="77b23bc8-8ecc-4ea9-8e75-e231a8da4f40">
-        <FirstName>Alice</FirstName>
-        <LastName>Miller</LastName>
-        <Age>65</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="b7979061-e500-41ba-82ed-252a855aa449" />
-            <Friend reference="2139f20d-b346-4518-9214-a235a041eb03" />
-            <Friend reference="4a2e0855-9ed3-40a6-8938-9d297e233251" />
-        </Friends>
-    </Person>
-    <Person id="0a07c6e5-f50b-4070-94ed-1192e57be736">
-        <FirstName>Eve</FirstName>
-        <LastName>Smith</LastName>
-        <Age>30</Age>
         <City>Rome</City>
         <Friends>
-            <Friend reference="ad902f4d-477f-4dc8-ac78-0915ce265808" />
-            <Friend reference="265ef9ee-9108-4332-9de3-ce837ab1ab79" />
-            <Friend reference="4eb57e1b-f0cd-4535-9b30-4f711df52897" />
+            <Friend reference="193" />
+            <Friend reference="110" />
+            <Friend reference="25" />
+            <Friend reference="10" />
+            <Friend reference="48" />
         </Friends>
     </Person>
-    <Person id="91e3a072-2875-4075-8f99-476e084bd0b8">
-        <FirstName>Eve</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>42</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="4a2e0855-9ed3-40a6-8938-9d297e233251" />
-            <Friend reference="4dea4278-b2f2-494d-b642-776ca344bba1" />
-            <Friend reference="155c9358-eb9a-413c-80c8-550a716d53fb" />
-            <Friend reference="5d88049c-517f-4cd6-bcaf-b4c20f622c7f" />
-            <Friend reference="8dbb43e9-a774-4bfe-bf91-888083c1fb87" />
-        </Friends>
-    </Person>
-    <Person id="a9d9b2cb-a849-4cf0-86d2-f579043c5f0b">
-        <FirstName>Grace</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>74</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="b7979061-e500-41ba-82ed-252a855aa449" />
-            <Friend reference="4a2e0855-9ed3-40a6-8938-9d297e233251" />
-        </Friends>
-    </Person>
-    <Person id="5d10e3a7-5544-47d7-901a-a7e8c196784b">
-        <FirstName>Ivy</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>28</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="c7062446-60e2-4e24-aa36-9dde41e31069" />
-            <Friend reference="7db08737-7701-48a9-8a79-9b8c97eda088" />
-            <Friend reference="d2ab86a8-2170-49ec-be6b-bf06de3da339" />
-        </Friends>
-    </Person>
-    <Person id="a1358452-5dee-4fa0-bc8b-bb956218d47d">
+    <Person id="140">
         <FirstName>Alice</FirstName>
-        <LastName>Johnson</LastName>
+        <LastName>Williams</LastName>
+        <Age>41</Age>
+        <City>New York</City>
+        <Friends>
+            <Friend reference="25" />
+            <Friend reference="45" />
+            <Friend reference="70" />
+        </Friends>
+    </Person>
+    <Person id="141">
+        <FirstName>Martin</FirstName>
+        <LastName>Garcia</LastName>
         <Age>49</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="6881d8fd-db6d-49e0-baa6-2fe6ab9ecd80" />
-            <Friend reference="7f1bcea1-20be-44a6-80ed-81a6018a6bf6" />
-            <Friend reference="8bc27905-d333-4e67-9ec5-64a36dfd3b19" />
-            <Friend reference="99028b3c-e796-4f50-83eb-dc3feebc2aeb" />
-        </Friends>
-    </Person>
-    <Person id="e424fbb5-5a32-44b4-ae40-d066990452b7">
-        <FirstName>Ivy</FirstName>
-        <LastName>Davis</LastName>
-        <Age>78</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="7f1bcea1-20be-44a6-80ed-81a6018a6bf6" />
-            <Friend reference="e6517e81-1153-4e15-b3c2-0ed2866a3e01" />
-            <Friend reference="91e3a072-2875-4075-8f99-476e084bd0b8" />
-            <Friend reference="9b0f80e0-d61d-477f-8774-338cec8363fa" />
-        </Friends>
-    </Person>
-    <Person id="8cfd0d48-cc44-43d4-af5a-7f9fda36c5d5">
-        <FirstName>Jack</FirstName>
-        <LastName>Jones</LastName>
-        <Age>64</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="265ef9ee-9108-4332-9de3-ce837ab1ab79" />
-            <Friend reference="7fdd054b-8f61-4918-9370-a3051868ba73" />
-        </Friends>
-    </Person>
-    <Person id="245e3a7c-488f-4fa4-817f-4f75dd35efd8">
-        <FirstName>Alice</FirstName>
-        <LastName>Miller</LastName>
-        <Age>44</Age>
         <City>New York</City>
         <Friends>
-            <Friend reference="e00f1baf-370a-4c7e-ba18-ea6dad59da75" />
-            <Friend reference="2d0b4716-f1a4-4dc8-87a4-0bca8932eef3" />
-            <Friend reference="adf87840-0353-4fcc-be64-5b123b3af58b" />
-            <Friend reference="24b7a10f-7391-4d12-9e50-a81f8da6c8b1" />
+            <Friend reference="111" />
         </Friends>
     </Person>
-    <Person id="7d3e3c2b-0324-416e-bf9b-90815d8aec90">
-        <FirstName>Grace</FirstName>
+    <Person id="142">
+        <FirstName>Eve</FirstName>
         <LastName>Wilson</LastName>
-        <Age>66</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="b95dd8df-3457-4b03-b486-ed39d125aa58" />
-            <Friend reference="e9d03a1c-7173-40e5-a023-c7a1c610e3ea" />
-            <Friend reference="e35289b1-ad46-4b44-b34b-59fc5246a808" />
-            <Friend reference="5e8f225a-4430-4230-b53f-a4106f659bbb" />
-            <Friend reference="f42249fb-f473-4124-8d05-65edfda4edf9" />
-        </Friends>
-    </Person>
-    <Person id="6aebd3c2-4707-44b9-86c5-ec6e90f03c6f">
-        <FirstName>Hank</FirstName>
-        <LastName>Smith</LastName>
-        <Age>27</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="99028b3c-e796-4f50-83eb-dc3feebc2aeb" />
-        </Friends>
-    </Person>
-    <Person id="fefaf6df-9a04-4d3f-8daf-315288a12492">
-        <FirstName>Ivy</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>78</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="6881d8fd-db6d-49e0-baa6-2fe6ab9ecd80" />
-            <Friend reference="255fcabe-b77a-4c2b-b98b-43cac3fc5cb0" />
-            <Friend reference="c26dda12-cf79-4f01-8a91-3c43229fa6d0" />
-            <Friend reference="e6517e81-1153-4e15-b3c2-0ed2866a3e01" />
-            <Friend reference="613a4c4e-02b2-4c8b-b2e2-3102471c54fb" />
-        </Friends>
-    </Person>
-    <Person id="77b8ebb1-58ea-48ea-ab53-351955ca5916">
-        <FirstName>Diana</FirstName>
-        <LastName>Smith</LastName>
-        <Age>22</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="a47c22d1-6279-475e-869b-8b9c644ab099" />
-        </Friends>
-    </Person>
-    <Person id="7f63d75e-ff54-46ab-8027-7194c1c4515f">
-        <FirstName>Diana</FirstName>
-        <LastName>Davis</LastName>
-        <Age>65</Age>
+        <Age>69</Age>
         <City>Sydney</City>
         <Friends>
-            <Friend reference="a47c22d1-6279-475e-869b-8b9c644ab099" />
-            <Friend reference="fad1cc81-c784-4f12-973c-c01f70c8aeb3" />
-            <Friend reference="26512242-d99a-4715-9dbe-b2ddbf8696e8" />
+            <Friend reference="18" />
+            <Friend reference="93" />
+            <Friend reference="48" />
+            <Friend reference="125" />
+            <Friend reference="74" />
         </Friends>
     </Person>
-    <Person id="805afc1e-0975-46e5-a04b-ea5ce119cb7c">
+    <Person id="143">
         <FirstName>Ivy</FirstName>
         <LastName>Williams</LastName>
-        <Age>54</Age>
-        <City>London</City>
+        <Age>53</Age>
+        <City>Sydney</City>
         <Friends>
-            <Friend reference="c0d0ddb9-d7d3-4cae-a329-3a031a24a248" />
-            <Friend reference="14921138-709b-421d-b4bd-300aa0f1a5eb" />
-            <Friend reference="ad4964fd-ac44-4613-9af1-55de566f7c39" />
-            <Friend reference="81e99fa8-c116-4b4d-8d9e-ab6ae65dbdf4" />
-            <Friend reference="d2ab86a8-2170-49ec-be6b-bf06de3da339" />
+            <Friend reference="75" />
+            <Friend reference="42" />
+            <Friend reference="0" />
         </Friends>
     </Person>
-    <Person id="9fd946b6-bebe-40ab-b5c6-f394e167eb89">
-        <FirstName>Bob</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>48</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="7f1bcea1-20be-44a6-80ed-81a6018a6bf6" />
-            <Friend reference="084e14f9-4f75-441c-a4c3-e21f6ecbb4af" />
-            <Friend reference="949718da-da2f-46b1-acfc-b1863206870c" />
-        </Friends>
-    </Person>
-    <Person id="265ef9ee-9108-4332-9de3-ce837ab1ab79">
-        <FirstName>Alice</FirstName>
-        <LastName>Brown</LastName>
-        <Age>37</Age>
-        <City>Toronto</City>
-        <Friends>
-            <Friend reference="2d0b4716-f1a4-4dc8-87a4-0bca8932eef3" />
-            <Friend reference="56d3d1ae-5797-400b-945a-53ced7f20cf9" />
-            <Friend reference="df5339a5-6cab-498c-b7d6-540c7c73c72b" />
-            <Friend reference="121f74df-c016-43e0-abc6-b87a2757db5d" />
-        </Friends>
-    </Person>
-    <Person id="7f1bcea1-20be-44a6-80ed-81a6018a6bf6">
-        <FirstName>Grace</FirstName>
-        <LastName>Jones</LastName>
-        <Age>36</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="a5d10382-c473-4565-a5a2-7eab5f71c7b5" />
-        </Friends>
-    </Person>
-    <Person id="9d6605f0-2a25-467e-95b3-b04210b7b31c">
-        <FirstName>Alice</FirstName>
-        <LastName>Williams</LastName>
-        <Age>54</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="bd14b1e1-b03d-4d2a-ad18-3352ec625db5" />
-            <Friend reference="3862037c-93a3-4fd9-8311-e73eba84d9d4" />
-        </Friends>
-    </Person>
-    <Person id="3862037c-93a3-4fd9-8311-e73eba84d9d4">
-        <FirstName>Jack</FirstName>
-        <LastName>Smith</LastName>
-        <Age>72</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="b95dd8df-3457-4b03-b486-ed39d125aa58" />
-            <Friend reference="99c66ce6-0fde-4b46-8f68-5de0d9f43251" />
-            <Friend reference="8bc27905-d333-4e67-9ec5-64a36dfd3b19" />
-        </Friends>
-    </Person>
-    <Person id="2819cf82-bf1a-4c73-aa7b-f4558644a4f8">
+    <Person id="144">
         <FirstName>Charlie</FirstName>
-        <LastName>Davis</LastName>
-        <Age>78</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="e4e5ee26-e1a4-4bb7-a5b6-f1f934e3f788" />
-            <Friend reference="cd1c1970-5471-46d7-a3d0-2c858348976e" />
-            <Friend reference="1cfd5461-a8d8-48fc-bb89-e2ae31406334" />
-            <Friend reference="0b75944b-3bb8-4859-bfe9-c6969ee6087a" />
-        </Friends>
-    </Person>
-    <Person id="ec065f2c-aabe-462c-ac4d-aa923b63b87f">
-        <FirstName>Eve</FirstName>
-        <LastName>Brown</LastName>
-        <Age>77</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="c17530ec-29b3-4b6f-83c5-cc39a84839a7" />
-            <Friend reference="ad4964fd-ac44-4613-9af1-55de566f7c39" />
-        </Friends>
-    </Person>
-    <Person id="de951b55-b673-438d-a3f6-b1845d51c043">
-        <FirstName>Diana</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>48</Age>
-        <City>Toronto</City>
-        <Friends>
-            <Friend reference="8bc27905-d333-4e67-9ec5-64a36dfd3b19" />
-        </Friends>
-    </Person>
-    <Person id="40252399-35ee-4d11-ba8b-001a719497ba">
-        <FirstName>Jack</FirstName>
-        <LastName>Martinez</LastName>
+        <LastName>Parker</LastName>
         <Age>61</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="a47c22d1-6279-475e-869b-8b9c644ab099" />
-            <Friend reference="4f080671-134e-4470-94e3-fa0ff20c053b" />
-        </Friends>
-    </Person>
-    <Person id="05af2781-6b3c-4e9b-8bd5-e427a2e0d2a6">
-        <FirstName>Alice</FirstName>
-        <LastName>Brown</LastName>
-        <Age>30</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="7f63d75e-ff54-46ab-8027-7194c1c4515f" />
-        </Friends>
-    </Person>
-    <Person id="496ff900-49ed-44f1-a55f-3b1fb395c30f">
-        <FirstName>Diana</FirstName>
-        <LastName>Smith</LastName>
-        <Age>54</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="ae5050b0-ba52-49dd-b560-a3829a9bd67a" />
-            <Friend reference="a47c22d1-6279-475e-869b-8b9c644ab099" />
-            <Friend reference="f42249fb-f473-4124-8d05-65edfda4edf9" />
-            <Friend reference="a1358452-5dee-4fa0-bc8b-bb956218d47d" />
-        </Friends>
-    </Person>
-    <Person id="aeac2952-83c2-433b-8577-87f9c60520fd">
-        <FirstName>Diana</FirstName>
-        <LastName>Jones</LastName>
-        <Age>55</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="8bc27905-d333-4e67-9ec5-64a36dfd3b19" />
-            <Friend reference="148ef794-de23-496d-83f1-9b76709e4e45" />
-            <Friend reference="a281cd79-5525-418e-91f6-6d3165d6a149" />
-        </Friends>
-    </Person>
-    <Person id="335d7a0a-dcb6-41d9-b75c-e6f54a32da71">
-        <FirstName>Alice</FirstName>
-        <LastName>Johnson</LastName>
-        <Age>50</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="8b02691d-e89c-4eb7-bad1-09b223cb8965" />
-            <Friend reference="5597a848-377b-4db0-9466-91ed7ecacbb1" />
-        </Friends>
-    </Person>
-    <Person id="35c49b17-a47d-4f03-9e1c-d89a6d2ec1a4">
-        <FirstName>Hank</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>30</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="ec88eb97-3472-41a5-b57b-facf2dc06236" />
-            <Friend reference="ab5d5185-aec8-4d66-9ba1-2474b42e1256" />
-        </Friends>
-    </Person>
-    <Person id="949718da-da2f-46b1-acfc-b1863206870c">
-        <FirstName>Jack</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>56</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="7c41e4de-41e0-4202-9441-b0fb61d39a7a" />
-        </Friends>
-    </Person>
-    <Person id="2ac0bf3b-7c3f-4aa7-8f22-433f9a002567">
-        <FirstName>Bob</FirstName>
-        <LastName>Miller</LastName>
-        <Age>33</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="25f00dbf-bae2-4c23-a43d-12a97337a354" />
-            <Friend reference="ec065f2c-aabe-462c-ac4d-aa923b63b87f" />
-            <Friend reference="0b2c05d0-51d3-4db7-b01a-84bba52804f9" />
-        </Friends>
-    </Person>
-    <Person id="89dfa723-bbf9-4452-bec9-c22841e2af3a">
-        <FirstName>Ivy</FirstName>
-        <LastName>Miller</LastName>
-        <Age>63</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="1cfd5461-a8d8-48fc-bb89-e2ae31406334" />
-            <Friend reference="99c66ce6-0fde-4b46-8f68-5de0d9f43251" />
-            <Friend reference="0e8af981-99bf-400a-937e-55dfbe99fe3d" />
-            <Friend reference="d7826fc5-4dbd-4fb4-a5c1-9e8b46344bd2" />
-        </Friends>
-    </Person>
-    <Person id="54f9ba76-d178-4064-b338-96765208669a">
-        <FirstName>Eve</FirstName>
-        <LastName>Davis</LastName>
-        <Age>75</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="055dc5f6-5a4a-4a8c-888a-d39745b8c87c" />
-            <Friend reference="4a2e0855-9ed3-40a6-8938-9d297e233251" />
-            <Friend reference="c17530ec-29b3-4b6f-83c5-cc39a84839a7" />
-        </Friends>
-    </Person>
-    <Person id="a5d10382-c473-4565-a5a2-7eab5f71c7b5">
-        <FirstName>Ivy</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>35</Age>
-        <City>Toronto</City>
-        <Friends>
-            <Friend reference="7bdbe39f-ffdc-409a-a671-899fce3ff56e" />
-            <Friend reference="1770a8ec-3368-4fca-81e1-71f26913b1f0" />
-            <Friend reference="121aae50-6caa-4759-9b65-b3a0f549630a" />
-            <Friend reference="c5eddc20-1fba-4ea2-b220-83e3b23daf41" />
-            <Friend reference="d2ab86a8-2170-49ec-be6b-bf06de3da339" />
-        </Friends>
-    </Person>
-    <Person id="b7979061-e500-41ba-82ed-252a855aa449">
-        <FirstName>Grace</FirstName>
-        <LastName>Jones</LastName>
-        <Age>62</Age>
         <City>Madrid</City>
         <Friends>
-            <Friend reference="2139f20d-b346-4518-9214-a235a041eb03" />
+            <Friend reference="173" />
+            <Friend reference="87" />
+            <Friend reference="57" />
+            <Friend reference="164" />
         </Friends>
     </Person>
-    <Person id="67b9c4bb-60ba-41c4-adeb-8d148b8527a1">
-        <FirstName>Eve</FirstName>
-        <LastName>Brown</LastName>
-        <Age>38</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="8b02691d-e89c-4eb7-bad1-09b223cb8965" />
-            <Friend reference="e6da0438-ec6c-49ff-bf57-3b72fecdded0" />
-            <Friend reference="2ea54c9b-c96d-4450-a8c2-b745d2f0ce75" />
-            <Friend reference="1145ca9b-02e5-4718-a8c1-90b433a624e0" />
-        </Friends>
-    </Person>
-    <Person id="f6509719-94b0-4b99-a164-1fe76a258c4e">
-        <FirstName>Frank</FirstName>
-        <LastName>Miller</LastName>
-        <Age>18</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="c68e591b-c46d-4835-bc16-57c5b170c6a0" />
-            <Friend reference="0bd509b0-5ff7-4611-b0c0-ab18c7f2fb12" />
-            <Friend reference="cd464b11-884f-4ce9-b864-c449b5d90825" />
-        </Friends>
-    </Person>
-    <Person id="b10b954a-cf7f-4be2-ac5a-bea8824e7ca5">
-        <FirstName>Diana</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>59</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="83441d1e-3751-45c7-826b-7bd615fdbaec" />
-            <Friend reference="99028b3c-e796-4f50-83eb-dc3feebc2aeb" />
-            <Friend reference="6aebd3c2-4707-44b9-86c5-ec6e90f03c6f" />
-            <Friend reference="54f9ba76-d178-4064-b338-96765208669a" />
-            <Friend reference="d7826fc5-4dbd-4fb4-a5c1-9e8b46344bd2" />
-        </Friends>
-    </Person>
-    <Person id="e6da0438-ec6c-49ff-bf57-3b72fecdded0">
-        <FirstName>Bob</FirstName>
-        <LastName>Jones</LastName>
-        <Age>25</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="89dfa723-bbf9-4452-bec9-c22841e2af3a" />
-        </Friends>
-    </Person>
-    <Person id="c20bda61-fa5f-4f12-b991-3e91a67e40bb">
-        <FirstName>Frank</FirstName>
-        <LastName>Miller</LastName>
-        <Age>73</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="e8960626-93c8-4610-a68b-27710b8c57a5" />
-            <Friend reference="7f63d75e-ff54-46ab-8027-7194c1c4515f" />
-            <Friend reference="53db431c-761f-4007-b4af-e75325c540dd" />
-            <Friend reference="ca74c7b4-5285-4e16-babd-c224efd5f62e" />
-        </Friends>
-    </Person>
-    <Person id="e00f1baf-370a-4c7e-ba18-ea6dad59da75">
-        <FirstName>Diana</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>31</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="d1afacd2-2ddc-4bfc-afe0-d389bccd8ac8" />
-        </Friends>
-    </Person>
-    <Person id="0b2c05d0-51d3-4db7-b01a-84bba52804f9">
-        <FirstName>Diana</FirstName>
-        <LastName>Smith</LastName>
-        <Age>49</Age>
-        <City>Toronto</City>
-        <Friends>
-            <Friend reference="a9d9b2cb-a849-4cf0-86d2-f579043c5f0b" />
-            <Friend reference="775badd5-73a2-4baa-8c8c-33932acb8d5e" />
-            <Friend reference="54f9ba76-d178-4064-b338-96765208669a" />
-        </Friends>
-    </Person>
-    <Person id="bcb73dae-32c7-4f35-9524-7ed463cb52da">
-        <FirstName>Alice</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>36</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="11a4ee19-6ab8-47d4-83b7-2802770f5fb7" />
-            <Friend reference="b10b954a-cf7f-4be2-ac5a-bea8824e7ca5" />
-            <Friend reference="084e14f9-4f75-441c-a4c3-e21f6ecbb4af" />
-            <Friend reference="055dc5f6-5a4a-4a8c-888a-d39745b8c87c" />
-            <Friend reference="dc45d46b-f6a7-4ad5-ba2c-3df52b6147d3" />
-        </Friends>
-    </Person>
-    <Person id="bfa085a9-e3f1-434c-8dfa-d3adbc4463e6">
-        <FirstName>Eve</FirstName>
-        <LastName>Miller</LastName>
-        <Age>31</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="ca74c7b4-5285-4e16-babd-c224efd5f62e" />
-        </Friends>
-    </Person>
-    <Person id="c5eddc20-1fba-4ea2-b220-83e3b23daf41">
-        <FirstName>Alice</FirstName>
-        <LastName>Johnson</LastName>
-        <Age>73</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="b755e758-8ab3-4afc-91ec-4aa0bd8f2bf1" />
-            <Friend reference="e4e5ee26-e1a4-4bb7-a5b6-f1f934e3f788" />
-        </Friends>
-    </Person>
-    <Person id="6881d8fd-db6d-49e0-baa6-2fe6ab9ecd80">
-        <FirstName>Charlie</FirstName>
-        <LastName>Williams</LastName>
-        <Age>72</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="a47c22d1-6279-475e-869b-8b9c644ab099" />
-            <Friend reference="8556f7fd-b6a6-402a-a333-62a9788caab5" />
-        </Friends>
-    </Person>
-    <Person id="ae5050b0-ba52-49dd-b560-a3829a9bd67a">
-        <FirstName>Frank</FirstName>
-        <LastName>Jones</LastName>
-        <Age>44</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="7bdbe39f-ffdc-409a-a671-899fce3ff56e" />
-            <Friend reference="650b05a1-b300-4ae6-8ce7-2494525d023b" />
-            <Friend reference="bd14b1e1-b03d-4d2a-ad18-3352ec625db5" />
-            <Friend reference="121f74df-c016-43e0-abc6-b87a2757db5d" />
-            <Friend reference="adf87840-0353-4fcc-be64-5b123b3af58b" />
-        </Friends>
-    </Person>
-    <Person id="148ef794-de23-496d-83f1-9b76709e4e45">
-        <FirstName>Eve</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>20</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="53db431c-761f-4007-b4af-e75325c540dd" />
-            <Friend reference="196d016c-ee46-4342-913e-fdb6084c733f" />
-            <Friend reference="71df4a30-ddbb-4bf8-a71a-b62a4e3e4d01" />
-            <Friend reference="77b23bc8-8ecc-4ea9-8e75-e231a8da4f40" />
-            <Friend reference="c68e591b-c46d-4835-bc16-57c5b170c6a0" />
-        </Friends>
-    </Person>
-    <Person id="4dea4278-b2f2-494d-b642-776ca344bba1">
-        <FirstName>Hank</FirstName>
-        <LastName>Brown</LastName>
-        <Age>33</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="ad902f4d-477f-4dc8-ac78-0915ce265808" />
-            <Friend reference="24b7a10f-7391-4d12-9e50-a81f8da6c8b1" />
-            <Friend reference="dc6ee606-68ff-43c9-8801-f7239d76ca75" />
-            <Friend reference="c68e591b-c46d-4835-bc16-57c5b170c6a0" />
-        </Friends>
-    </Person>
-    <Person id="7fdd054b-8f61-4918-9370-a3051868ba73">
-        <FirstName>Bob</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>38</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="99028b3c-e796-4f50-83eb-dc3feebc2aeb" />
-            <Friend reference="121f74df-c016-43e0-abc6-b87a2757db5d" />
-            <Friend reference="a281cd79-5525-418e-91f6-6d3165d6a149" />
-            <Friend reference="e8960626-93c8-4610-a68b-27710b8c57a5" />
-        </Friends>
-    </Person>
-    <Person id="edd61ad0-72a8-4024-95d4-5328035a345a">
-        <FirstName>Hank</FirstName>
-        <LastName>Jones</LastName>
-        <Age>51</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="f6509719-94b0-4b99-a164-1fe76a258c4e" />
-            <Friend reference="a88f80d2-be27-45ba-874f-f99cc3670d79" />
-            <Friend reference="b87a06ee-1e6d-4539-ae2d-c3fe2a7fe3fe" />
-            <Friend reference="5a361aa2-947b-4b8b-8127-2a5e1a5b8c91" />
-            <Friend reference="adf87840-0353-4fcc-be64-5b123b3af58b" />
-        </Friends>
-    </Person>
-    <Person id="2139f20d-b346-4518-9214-a235a041eb03">
-        <FirstName>Diana</FirstName>
-        <LastName>Davis</LastName>
-        <Age>70</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="f6509719-94b0-4b99-a164-1fe76a258c4e" />
-            <Friend reference="c20bda61-fa5f-4f12-b991-3e91a67e40bb" />
-            <Friend reference="b6207793-6a1f-467b-900d-1387f528fafb" />
-            <Friend reference="4eb57e1b-f0cd-4535-9b30-4f711df52897" />
-        </Friends>
-    </Person>
-    <Person id="8dbb43e9-a774-4bfe-bf91-888083c1fb87">
-        <FirstName>Grace</FirstName>
-        <LastName>Davis</LastName>
-        <Age>39</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="9017d323-0a52-443d-a966-bb4cfd391927" />
-            <Friend reference="0b2c05d0-51d3-4db7-b01a-84bba52804f9" />
-            <Friend reference="148ef794-de23-496d-83f1-9b76709e4e45" />
-        </Friends>
-    </Person>
-    <Person id="4ddd491d-8cad-47b7-ba64-6b7b6bbde541">
-        <FirstName>Alice</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>63</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="949718da-da2f-46b1-acfc-b1863206870c" />
-            <Friend reference="fad1cc81-c784-4f12-973c-c01f70c8aeb3" />
-            <Friend reference="50052d30-0320-4c70-a20f-8c6935956019" />
-            <Friend reference="d7826fc5-4dbd-4fb4-a5c1-9e8b46344bd2" />
-            <Friend reference="0aed9f46-bd40-482d-b1db-2025675f70f2" />
-        </Friends>
-    </Person>
-    <Person id="2d0b4716-f1a4-4dc8-87a4-0bca8932eef3">
-        <FirstName>Hank</FirstName>
-        <LastName>Jones</LastName>
-        <Age>29</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="e8960626-93c8-4610-a68b-27710b8c57a5" />
-            <Friend reference="47dd4c47-da28-4c9c-81e4-c363dde507c3" />
-            <Friend reference="cd1c1970-5471-46d7-a3d0-2c858348976e" />
-            <Friend reference="bfa085a9-e3f1-434c-8dfa-d3adbc4463e6" />
-        </Friends>
-    </Person>
-    <Person id="bec92eb3-a4b1-4421-8933-bad3a1ed702b">
-        <FirstName>Eve</FirstName>
-        <LastName>Davis</LastName>
-        <Age>73</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="513257d5-140e-4d2d-89f7-237c8b025883" />
-            <Friend reference="15b7523e-388f-40af-ac33-31332ffd5f10" />
-            <Friend reference="b95dd8df-3457-4b03-b486-ed39d125aa58" />
-            <Friend reference="4eb57e1b-f0cd-4535-9b30-4f711df52897" />
-            <Friend reference="a47670a2-b226-4851-9a86-f8f51e8040f7" />
-        </Friends>
-    </Person>
-    <Person id="85eed631-648d-449c-8b69-b5b4d63c52fb">
-        <FirstName>Bob</FirstName>
-        <LastName>Davis</LastName>
-        <Age>69</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="89dfa723-bbf9-4452-bec9-c22841e2af3a" />
-            <Friend reference="084e14f9-4f75-441c-a4c3-e21f6ecbb4af" />
-            <Friend reference="496ff900-49ed-44f1-a55f-3b1fb395c30f" />
-            <Friend reference="7db08737-7701-48a9-8a79-9b8c97eda088" />
-            <Friend reference="df5339a5-6cab-498c-b7d6-540c7c73c72b" />
-        </Friends>
-    </Person>
-    <Person id="55fa2b5c-8e26-4f7a-b9e4-e003144cfb20">
-        <FirstName>Ivy</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>25</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="2892a631-2ed3-4055-91ce-80d75de3b9fa" />
-            <Friend reference="5974ddd5-4f85-49b5-8306-f77d281966ad" />
-            <Friend reference="c2fb52c1-73d4-4c3f-8221-7e642747e282" />
-        </Friends>
-    </Person>
-    <Person id="2ea54c9b-c96d-4450-a8c2-b745d2f0ce75">
-        <FirstName>Hank</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>28</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="a5d10382-c473-4565-a5a2-7eab5f71c7b5" />
-            <Friend reference="0aed9f46-bd40-482d-b1db-2025675f70f2" />
-        </Friends>
-    </Person>
-    <Person id="ad902f4d-477f-4dc8-ac78-0915ce265808">
-        <FirstName>Charlie</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>39</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="0e8af981-99bf-400a-937e-55dfbe99fe3d" />
-            <Friend reference="d1afacd2-2ddc-4bfc-afe0-d389bccd8ac8" />
-            <Friend reference="042ea171-71bd-4e0c-b669-ccc501b7089f" />
-            <Friend reference="4ddd491d-8cad-47b7-ba64-6b7b6bbde541" />
-            <Friend reference="bec92eb3-a4b1-4421-8933-bad3a1ed702b" />
-        </Friends>
-    </Person>
-    <Person id="71df4a30-ddbb-4bf8-a71a-b62a4e3e4d01">
-        <FirstName>Alice</FirstName>
-        <LastName>Brown</LastName>
-        <Age>27</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="4f080671-134e-4470-94e3-fa0ff20c053b" />
-            <Friend reference="a281cd79-5525-418e-91f6-6d3165d6a149" />
-            <Friend reference="ae5050b0-ba52-49dd-b560-a3829a9bd67a" />
-        </Friends>
-    </Person>
-    <Person id="733b4fdf-7420-4e55-9006-a0db853afb53">
-        <FirstName>Hank</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>65</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="4229ffc5-9a59-43bd-931a-d7715bb323de" />
-            <Friend reference="9d6605f0-2a25-467e-95b3-b04210b7b31c" />
-            <Friend reference="9fd946b6-bebe-40ab-b5c6-f394e167eb89" />
-            <Friend reference="0e724252-57ba-4b24-9c4b-9016f7c0afac" />
-        </Friends>
-    </Person>
-    <Person id="e8960626-93c8-4610-a68b-27710b8c57a5">
-        <FirstName>Grace</FirstName>
-        <LastName>Jones</LastName>
-        <Age>43</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="79a7d514-2127-4865-9722-7a9d96ff9587" />
-            <Friend reference="fefaf6df-9a04-4d3f-8daf-315288a12492" />
-            <Friend reference="8b02691d-e89c-4eb7-bad1-09b223cb8965" />
-        </Friends>
-    </Person>
-    <Person id="dc6ee606-68ff-43c9-8801-f7239d76ca75">
-        <FirstName>Bob</FirstName>
-        <LastName>Smith</LastName>
-        <Age>34</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="121f74df-c016-43e0-abc6-b87a2757db5d" />
-            <Friend reference="7f1bcea1-20be-44a6-80ed-81a6018a6bf6" />
-            <Friend reference="c17530ec-29b3-4b6f-83c5-cc39a84839a7" />
-            <Friend reference="0e0d7f43-5cc5-414e-b272-9fad36aa1a0f" />
-        </Friends>
-    </Person>
-    <Person id="66eca3bd-665f-4cb3-92f1-ccab02a53d0a">
-        <FirstName>Hank</FirstName>
-        <LastName>Johnson</LastName>
-        <Age>68</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="89dfa723-bbf9-4452-bec9-c22841e2af3a" />
-            <Friend reference="d2ab86a8-2170-49ec-be6b-bf06de3da339" />
-        </Friends>
-    </Person>
-    <Person id="e6517e81-1153-4e15-b3c2-0ed2866a3e01">
-        <FirstName>Diana</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>27</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="66eca3bd-665f-4cb3-92f1-ccab02a53d0a" />
-            <Friend reference="805afc1e-0975-46e5-a04b-ea5ce119cb7c" />
-            <Friend reference="b6207793-6a1f-467b-900d-1387f528fafb" />
-            <Friend reference="03c2b774-d323-414b-93e2-5451e2508393" />
-        </Friends>
-    </Person>
-    <Person id="e4e5ee26-e1a4-4bb7-a5b6-f1f934e3f788">
-        <FirstName>Frank</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>54</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="4eb57e1b-f0cd-4535-9b30-4f711df52897" />
-            <Friend reference="5cc3d307-4b82-4cba-8203-c98a1c8dac47" />
-            <Friend reference="aebc1922-0238-4183-b046-43bf7e6f76ed" />
-        </Friends>
-    </Person>
-    <Person id="a281cd79-5525-418e-91f6-6d3165d6a149">
-        <FirstName>Hank</FirstName>
-        <LastName>Smith</LastName>
-        <Age>19</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="a9532859-004e-42a9-96d4-384a139fd05d" />
-            <Friend reference="0e0d7f43-5cc5-414e-b272-9fad36aa1a0f" />
-            <Friend reference="196d016c-ee46-4342-913e-fdb6084c733f" />
-            <Friend reference="c2fb52c1-73d4-4c3f-8221-7e642747e282" />
-        </Friends>
-    </Person>
-    <Person id="ab5d5185-aec8-4d66-9ba1-2474b42e1256">
+    <Person id="145">
         <FirstName>Jack</FirstName>
         <LastName>Brown</LastName>
-        <Age>20</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="89dfa723-bbf9-4452-bec9-c22841e2af3a" />
-            <Friend reference="54f9ba76-d178-4064-b338-96765208669a" />
-        </Friends>
-    </Person>
-    <Person id="c7062446-60e2-4e24-aa36-9dde41e31069">
-        <FirstName>Diana</FirstName>
-        <LastName>Miller</LastName>
-        <Age>36</Age>
-        <City>Toronto</City>
-        <Friends>
-            <Friend reference="7fdd054b-8f61-4918-9370-a3051868ba73" />
-        </Friends>
-    </Person>
-    <Person id="9017d323-0a52-443d-a966-bb4cfd391927">
-        <FirstName>Jack</FirstName>
-        <LastName>Jones</LastName>
-        <Age>73</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="f42249fb-f473-4124-8d05-65edfda4edf9" />
-            <Friend reference="ae5050b0-ba52-49dd-b560-a3829a9bd67a" />
-            <Friend reference="1cfd5461-a8d8-48fc-bb89-e2ae31406334" />
-            <Friend reference="bbd10667-0224-4e86-a89a-8e23dfc12ea9" />
-            <Friend reference="c2fb52c1-73d4-4c3f-8221-7e642747e282" />
-        </Friends>
-    </Person>
-    <Person id="03c2b774-d323-414b-93e2-5451e2508393">
-        <FirstName>Hank</FirstName>
-        <LastName>Miller</LastName>
-        <Age>69</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="613a4c4e-02b2-4c8b-b2e2-3102471c54fb" />
-            <Friend reference="e8960626-93c8-4610-a68b-27710b8c57a5" />
-            <Friend reference="c5eddc20-1fba-4ea2-b220-83e3b23daf41" />
-        </Friends>
-    </Person>
-    <Person id="ebb01581-aea4-4ff8-bb00-4d1c673cc03a">
-        <FirstName>Ivy</FirstName>
-        <LastName>Williams</LastName>
-        <Age>66</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="15b7523e-388f-40af-ac33-31332ffd5f10" />
-            <Friend reference="5d10e3a7-5544-47d7-901a-a7e8c196784b" />
-            <Friend reference="edd61ad0-72a8-4024-95d4-5328035a345a" />
-        </Friends>
-    </Person>
-    <Person id="1770a8ec-3368-4fca-81e1-71f26913b1f0">
-        <FirstName>Ivy</FirstName>
-        <LastName>Johnson</LastName>
-        <Age>79</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="db43912a-fc76-4286-a017-479c11da344a" />
-            <Friend reference="0b75944b-3bb8-4859-bfe9-c6969ee6087a" />
-            <Friend reference="726ca190-bdb2-45c9-b70f-6625f29dc482" />
-            <Friend reference="03c2b774-d323-414b-93e2-5451e2508393" />
-        </Friends>
-    </Person>
-    <Person id="248b4feb-2a86-4e90-b1ed-6932550e9b54">
-        <FirstName>Eve</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>42</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="c5eddc20-1fba-4ea2-b220-83e3b23daf41" />
-            <Friend reference="df5339a5-6cab-498c-b7d6-540c7c73c72b" />
-            <Friend reference="650b05a1-b300-4ae6-8ce7-2494525d023b" />
-            <Friend reference="ab5d5185-aec8-4d66-9ba1-2474b42e1256" />
-        </Friends>
-    </Person>
-    <Person id="d2ab86a8-2170-49ec-be6b-bf06de3da339">
-        <FirstName>Charlie</FirstName>
-        <LastName>Johnson</LastName>
-        <Age>74</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="9017d323-0a52-443d-a966-bb4cfd391927" />
-        </Friends>
-    </Person>
-    <Person id="084e14f9-4f75-441c-a4c3-e21f6ecbb4af">
-        <FirstName>Hank</FirstName>
-        <LastName>Davis</LastName>
-        <Age>50</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="dc6ee606-68ff-43c9-8801-f7239d76ca75" />
-            <Friend reference="bd14b1e1-b03d-4d2a-ad18-3352ec625db5" />
-            <Friend reference="a9d9b2cb-a849-4cf0-86d2-f579043c5f0b" />
-            <Friend reference="8556f7fd-b6a6-402a-a333-62a9788caab5" />
-            <Friend reference="52d4d91e-6c14-4c34-a537-2d26e2c2a3e5" />
-        </Friends>
-    </Person>
-    <Person id="c17530ec-29b3-4b6f-83c5-cc39a84839a7">
-        <FirstName>Hank</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>38</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="47dd4c47-da28-4c9c-81e4-c363dde507c3" />
-            <Friend reference="148ef794-de23-496d-83f1-9b76709e4e45" />
-            <Friend reference="723b7831-2d3e-49db-82bb-804cb52955ac" />
-            <Friend reference="85eed631-648d-449c-8b69-b5b4d63c52fb" />
-        </Friends>
-    </Person>
-    <Person id="00eb74b0-9258-4026-8ac7-155fed542770">
-        <FirstName>Eve</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>28</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="7cf30bf3-a868-41c4-a072-ae33ba77c2ca" />
-            <Friend reference="0b2c05d0-51d3-4db7-b01a-84bba52804f9" />
-            <Friend reference="5e8f225a-4430-4230-b53f-a4106f659bbb" />
-        </Friends>
-    </Person>
-    <Person id="56d3d1ae-5797-400b-945a-53ced7f20cf9">
-        <FirstName>Frank</FirstName>
-        <LastName>Smith</LastName>
-        <Age>44</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="a47307ef-a06b-45b2-8473-16070826bfe5" />
-            <Friend reference="5974ddd5-4f85-49b5-8306-f77d281966ad" />
-            <Friend reference="40252399-35ee-4d11-ba8b-001a719497ba" />
-        </Friends>
-    </Person>
-    <Person id="d57fb7f5-3eb5-4c12-b4b9-86e31390c7e4">
-        <FirstName>Hank</FirstName>
-        <LastName>Smith</LastName>
-        <Age>18</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="8a29dd15-f5a8-4305-a2f2-3d69b58b7385" />
-            <Friend reference="df5339a5-6cab-498c-b7d6-540c7c73c72b" />
-            <Friend reference="28bffb13-dc29-4d94-a996-42e5ffb929a7" />
-        </Friends>
-    </Person>
-    <Person id="e9d03a1c-7173-40e5-a023-c7a1c610e3ea">
-        <FirstName>Jack</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>52</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="0b75944b-3bb8-4859-bfe9-c6969ee6087a" />
-        </Friends>
-    </Person>
-    <Person id="0aed9f46-bd40-482d-b1db-2025675f70f2">
-        <FirstName>Jack</FirstName>
-        <LastName>Jones</LastName>
-        <Age>59</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="121f74df-c016-43e0-abc6-b87a2757db5d" />
-            <Friend reference="4eec3876-ffad-4a3a-a931-3af9f6f2a68a" />
-            <Friend reference="99c66ce6-0fde-4b46-8f68-5de0d9f43251" />
-        </Friends>
-    </Person>
-    <Person id="9d2ce7c3-1276-4b7c-8a87-6b5ed60753da">
-        <FirstName>Frank</FirstName>
-        <LastName>Brown</LastName>
-        <Age>24</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="7f63d75e-ff54-46ab-8027-7194c1c4515f" />
-            <Friend reference="14921138-709b-421d-b4bd-300aa0f1a5eb" />
-            <Friend reference="78c8043b-2aa8-4ea7-a5db-bc978f1d5804" />
-        </Friends>
-    </Person>
-    <Person id="1cfd5461-a8d8-48fc-bb89-e2ae31406334">
-        <FirstName>Charlie</FirstName>
-        <LastName>Miller</LastName>
-        <Age>54</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="7c41e4de-41e0-4202-9441-b0fb61d39a7a" />
-            <Friend reference="116ee3ff-dde2-415d-b573-927cf83ca146" />
-            <Friend reference="8cfd0d48-cc44-43d4-af5a-7f9fda36c5d5" />
-        </Friends>
-    </Person>
-    <Person id="a9532859-004e-42a9-96d4-384a139fd05d">
-        <FirstName>Ivy</FirstName>
-        <LastName>Brown</LastName>
-        <Age>24</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="2d0b4716-f1a4-4dc8-87a4-0bca8932eef3" />
-            <Friend reference="aeac2952-83c2-433b-8577-87f9c60520fd" />
-            <Friend reference="0bd509b0-5ff7-4611-b0c0-ab18c7f2fb12" />
-            <Friend reference="40252399-35ee-4d11-ba8b-001a719497ba" />
-            <Friend reference="265ef9ee-9108-4332-9de3-ce837ab1ab79" />
-        </Friends>
-    </Person>
-    <Person id="5d88049c-517f-4cd6-bcaf-b4c20f622c7f">
-        <FirstName>Eve</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>42</Age>
-        <City>Toronto</City>
-        <Friends>
-            <Friend reference="0b2c05d0-51d3-4db7-b01a-84bba52804f9" />
-            <Friend reference="0e724252-57ba-4b24-9c4b-9016f7c0afac" />
-            <Friend reference="91e3a072-2875-4075-8f99-476e084bd0b8" />
-            <Friend reference="99c66ce6-0fde-4b46-8f68-5de0d9f43251" />
-            <Friend reference="a7b5ab4a-4084-49b4-b2ee-a71497a2bbba" />
-        </Friends>
-    </Person>
-    <Person id="38fe9332-046b-4145-8c9a-9801f0249211">
-        <FirstName>Diana</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>43</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="e6517e81-1153-4e15-b3c2-0ed2866a3e01" />
-            <Friend reference="335d7a0a-dcb6-41d9-b75c-e6f54a32da71" />
-            <Friend reference="df5339a5-6cab-498c-b7d6-540c7c73c72b" />
-            <Friend reference="055dc5f6-5a4a-4a8c-888a-d39745b8c87c" />
-            <Friend reference="5d88049c-517f-4cd6-bcaf-b4c20f622c7f" />
-        </Friends>
-    </Person>
-    <Person id="7c41e4de-41e0-4202-9441-b0fb61d39a7a">
-        <FirstName>Frank</FirstName>
-        <LastName>Brown</LastName>
-        <Age>60</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="a47307ef-a06b-45b2-8473-16070826bfe5" />
-            <Friend reference="d7826fc5-4dbd-4fb4-a5c1-9e8b46344bd2" />
-            <Friend reference="2d0b4716-f1a4-4dc8-87a4-0bca8932eef3" />
-            <Friend reference="196d016c-ee46-4342-913e-fdb6084c733f" />
-            <Friend reference="307ff5b2-a10d-42f1-b7a3-79274fb47669" />
-        </Friends>
-    </Person>
-    <Person id="5a361aa2-947b-4b8b-8127-2a5e1a5b8c91">
-        <FirstName>Jack</FirstName>
-        <LastName>Davis</LastName>
-        <Age>62</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="81e99fa8-c116-4b4d-8d9e-ab6ae65dbdf4" />
-            <Friend reference="ec88eb97-3472-41a5-b57b-facf2dc06236" />
-        </Friends>
-    </Person>
-    <Person id="c68e591b-c46d-4835-bc16-57c5b170c6a0">
-        <FirstName>Ivy</FirstName>
-        <LastName>Johnson</LastName>
-        <Age>38</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="733b4fdf-7420-4e55-9006-a0db853afb53" />
-        </Friends>
-    </Person>
-    <Person id="fad1cc81-c784-4f12-973c-c01f70c8aeb3">
-        <FirstName>Jack</FirstName>
-        <LastName>Smith</LastName>
-        <Age>58</Age>
-        <City>Toronto</City>
-        <Friends>
-            <Friend reference="7db08737-7701-48a9-8a79-9b8c97eda088" />
-            <Friend reference="f2a5ae1d-731a-4e22-a097-62048fddde2a" />
-            <Friend reference="9ac4ec64-f272-4652-bccb-f86b0b32e833" />
-            <Friend reference="8b02691d-e89c-4eb7-bad1-09b223cb8965" />
-        </Friends>
-    </Person>
-    <Person id="db808525-3b9c-4040-abf9-f15b1f419808">
-        <FirstName>Bob</FirstName>
-        <LastName>Williams</LastName>
-        <Age>19</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="c17530ec-29b3-4b6f-83c5-cc39a84839a7" />
-            <Friend reference="9d6605f0-2a25-467e-95b3-b04210b7b31c" />
-        </Friends>
-    </Person>
-    <Person id="0e0d7f43-5cc5-414e-b272-9fad36aa1a0f">
-        <FirstName>Hank</FirstName>
-        <LastName>Johnson</LastName>
-        <Age>64</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="925194d6-ff51-4afd-9faa-3b741543f803" />
-            <Friend reference="9d2ce7c3-1276-4b7c-8a87-6b5ed60753da" />
-            <Friend reference="85eed631-648d-449c-8b69-b5b4d63c52fb" />
-        </Friends>
-    </Person>
-    <Person id="dc45d46b-f6a7-4ad5-ba2c-3df52b6147d3">
-        <FirstName>Grace</FirstName>
-        <LastName>Smith</LastName>
-        <Age>35</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="0a07c6e5-f50b-4070-94ed-1192e57be736" />
-            <Friend reference="a281cd79-5525-418e-91f6-6d3165d6a149" />
-            <Friend reference="0e8af981-99bf-400a-937e-55dfbe99fe3d" />
-        </Friends>
-    </Person>
-    <Person id="81e99fa8-c116-4b4d-8d9e-ab6ae65dbdf4">
-        <FirstName>Eve</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>62</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="121f74df-c016-43e0-abc6-b87a2757db5d" />
-            <Friend reference="25f00dbf-bae2-4c23-a43d-12a97337a354" />
-            <Friend reference="c20bda61-fa5f-4f12-b991-3e91a67e40bb" />
-            <Friend reference="bd14b1e1-b03d-4d2a-ad18-3352ec625db5" />
-            <Friend reference="0e0d7f43-5cc5-414e-b272-9fad36aa1a0f" />
-        </Friends>
-    </Person>
-    <Person id="81b1fed4-ed60-44fc-a985-ad0321cbd648">
-        <FirstName>Diana</FirstName>
-        <LastName>Williams</LastName>
-        <Age>51</Age>
-        <City>Paris</City>
-        <Friends>
-            <Friend reference="c68e591b-c46d-4835-bc16-57c5b170c6a0" />
-            <Friend reference="91e3a072-2875-4075-8f99-476e084bd0b8" />
-        </Friends>
-    </Person>
-    <Person id="a47307ef-a06b-45b2-8473-16070826bfe5">
-        <FirstName>Charlie</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>40</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="9fd946b6-bebe-40ab-b5c6-f394e167eb89" />
-            <Friend reference="b95dd8df-3457-4b03-b486-ed39d125aa58" />
-            <Friend reference="2139f20d-b346-4518-9214-a235a041eb03" />
-            <Friend reference="148ef794-de23-496d-83f1-9b76709e4e45" />
-        </Friends>
-    </Person>
-    <Person id="24b7a10f-7391-4d12-9e50-a81f8da6c8b1">
-        <FirstName>Alice</FirstName>
-        <LastName>Johnson</LastName>
         <Age>21</Age>
-        <City>Sydney</City>
+        <City>Washington</City>
         <Friends>
-            <Friend reference="78c8043b-2aa8-4ea7-a5db-bc978f1d5804" />
+            <Friend reference="178" />
         </Friends>
     </Person>
-    <Person id="4a2e0855-9ed3-40a6-8938-9d297e233251">
+    <Person id="146">
+        <FirstName>Steve</FirstName>
+        <LastName>Wilson</LastName>
+        <Age>64</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="179" />
+            <Friend reference="18" />
+            <Friend reference="123" />
+            <Friend reference="48" />
+        </Friends>
+    </Person>
+    <Person id="147">
+        <FirstName>Martin</FirstName>
+        <LastName>Smith</LastName>
+        <Age>31</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="170" />
+            <Friend reference="187" />
+            <Friend reference="52" />
+            <Friend reference="99" />
+            <Friend reference="117" />
+        </Friends>
+    </Person>
+    <Person id="148">
         <FirstName>Jack</FirstName>
-        <LastName>Davis</LastName>
-        <Age>69</Age>
+        <LastName>Parker</LastName>
+        <Age>45</Age>
         <City>New York</City>
         <Friends>
-            <Friend reference="925194d6-ff51-4afd-9faa-3b741543f803" />
+            <Friend reference="75" />
+            <Friend reference="194" />
+            <Friend reference="128" />
+            <Friend reference="18" />
+            <Friend reference="19" />
         </Friends>
     </Person>
-    <Person id="7a07a43d-b8bd-4bc7-886c-2fa879f94041">
-        <FirstName>Jack</FirstName>
-        <LastName>Davis</LastName>
-        <Age>40</Age>
+    <Person id="149">
+        <FirstName>Eve</FirstName>
+        <LastName>Williams</LastName>
+        <Age>50</Age>
+        <City>Toronto</City>
+        <Friends>
+            <Friend reference="153" />
+            <Friend reference="172" />
+            <Friend reference="83" />
+            <Friend reference="0" />
+        </Friends>
+    </Person>
+    <Person id="150">
+        <FirstName>David</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>23</Age>
         <City>Madrid</City>
         <Friends>
-            <Friend reference="1770a8ec-3368-4fca-81e1-71f26913b1f0" />
-            <Friend reference="5597a848-377b-4db0-9466-91ed7ecacbb1" />
-            <Friend reference="513257d5-140e-4d2d-89f7-237c8b025883" />
-            <Friend reference="c0d0ddb9-d7d3-4cae-a329-3a031a24a248" />
-            <Friend reference="adf87840-0353-4fcc-be64-5b123b3af58b" />
+            <Friend reference="118" />
+            <Friend reference="145" />
+            <Friend reference="181" />
+            <Friend reference="194" />
         </Friends>
     </Person>
-    <Person id="775badd5-73a2-4baa-8c8c-33932acb8d5e">
-        <FirstName>Frank</FirstName>
+    <Person id="151">
+        <FirstName>Hank</FirstName>
         <LastName>Johnson</LastName>
-        <Age>74</Age>
+        <Age>69</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="20" />
+        </Friends>
+    </Person>
+    <Person id="152">
+        <FirstName>Alice</FirstName>
+        <LastName>Smith</LastName>
+        <Age>75</Age>
         <City>Rome</City>
         <Friends>
-            <Friend reference="513257d5-140e-4d2d-89f7-237c8b025883" />
-            <Friend reference="8a29dd15-f5a8-4305-a2f2-3d69b58b7385" />
-            <Friend reference="3862037c-93a3-4fd9-8311-e73eba84d9d4" />
-            <Friend reference="4eb57e1b-f0cd-4535-9b30-4f711df52897" />
+            <Friend reference="139" />
         </Friends>
     </Person>
-    <Person id="db43912a-fc76-4286-a017-479c11da344a">
-        <FirstName>Bob</FirstName>
-        <LastName>Wilson</LastName>
-        <Age>65</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="91e3a072-2875-4075-8f99-476e084bd0b8" />
-            <Friend reference="042ea171-71bd-4e0c-b669-ccc501b7089f" />
-            <Friend reference="1cfd5461-a8d8-48fc-bb89-e2ae31406334" />
-            <Friend reference="c17530ec-29b3-4b6f-83c5-cc39a84839a7" />
-            <Friend reference="1770a8ec-3368-4fca-81e1-71f26913b1f0" />
-        </Friends>
-    </Person>
-    <Person id="4eb57e1b-f0cd-4535-9b30-4f711df52897">
-        <FirstName>Jack</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>30</Age>
-        <City>Belgrade</City>
-        <Friends>
-            <Friend reference="116ee3ff-dde2-415d-b573-927cf83ca146" />
-            <Friend reference="4229ffc5-9a59-43bd-931a-d7715bb323de" />
-            <Friend reference="91e3a072-2875-4075-8f99-476e084bd0b8" />
-            <Friend reference="9fd946b6-bebe-40ab-b5c6-f394e167eb89" />
-        </Friends>
-    </Person>
-    <Person id="5cc3d307-4b82-4cba-8203-c98a1c8dac47">
-        <FirstName>Frank</FirstName>
+    <Person id="153">
+        <FirstName>Eve</FirstName>
         <LastName>Johnson</LastName>
-        <Age>24</Age>
-        <City>New York</City>
-        <Friends>
-            <Friend reference="7717505e-c0da-449c-8077-ff5e0fc31053" />
-            <Friend reference="25f00dbf-bae2-4c23-a43d-12a97337a354" />
-            <Friend reference="4229ffc5-9a59-43bd-931a-d7715bb323de" />
-            <Friend reference="1c8e478d-53b0-4aec-974b-e670a5cd2019" />
-            <Friend reference="f6509719-94b0-4b99-a164-1fe76a258c4e" />
-        </Friends>
-    </Person>
-    <Person id="0e8af981-99bf-400a-937e-55dfbe99fe3d">
-        <FirstName>Charlie</FirstName>
-        <LastName>Williams</LastName>
-        <Age>32</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="77b8ebb1-58ea-48ea-ab53-351955ca5916" />
-            <Friend reference="db43912a-fc76-4286-a017-479c11da344a" />
-            <Friend reference="0e0d7f43-5cc5-414e-b272-9fad36aa1a0f" />
-            <Friend reference="5a361aa2-947b-4b8b-8127-2a5e1a5b8c91" />
-            <Friend reference="733b4fdf-7420-4e55-9006-a0db853afb53" />
-        </Friends>
-    </Person>
-    <Person id="2892a631-2ed3-4055-91ce-80d75de3b9fa">
-        <FirstName>Hank</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>31</Age>
+        <Age>46</Age>
         <City>Paris</City>
         <Friends>
-            <Friend reference="15b7523e-388f-40af-ac33-31332ffd5f10" />
-            <Friend reference="fad1cc81-c784-4f12-973c-c01f70c8aeb3" />
+            <Friend reference="92" />
+            <Friend reference="136" />
+            <Friend reference="86" />
+            <Friend reference="165" />
+            <Friend reference="32" />
         </Friends>
     </Person>
-    <Person id="c2fb52c1-73d4-4c3f-8221-7e642747e282">
+    <Person id="154">
+        <FirstName>Frank</FirstName>
+        <LastName>Davis</LastName>
+        <Age>54</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="193" />
+            <Friend reference="185" />
+        </Friends>
+    </Person>
+    <Person id="155">
+        <FirstName>Ivy</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>80</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="70" />
+        </Friends>
+    </Person>
+    <Person id="156">
+        <FirstName>Frank</FirstName>
+        <LastName>Smith</LastName>
+        <Age>44</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="10" />
+            <Friend reference="99" />
+            <Friend reference="75" />
+            <Friend reference="12" />
+            <Friend reference="197" />
+        </Friends>
+    </Person>
+    <Person id="157">
+        <FirstName>Ivy</FirstName>
+        <LastName>Jones</LastName>
+        <Age>37</Age>
+        <City>Ohio</City>
+        <Friends>
+            <Friend reference="8" />
+            <Friend reference="129" />
+            <Friend reference="65" />
+        </Friends>
+    </Person>
+    <Person id="158">
+        <FirstName>Bob</FirstName>
+        <LastName>Smith</LastName>
+        <Age>33</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="81" />
+        </Friends>
+    </Person>
+    <Person id="159">
+        <FirstName>Bob</FirstName>
+        <LastName>Wilson</LastName>
+        <Age>28</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="154" />
+        </Friends>
+    </Person>
+    <Person id="160">
+        <FirstName>Bob</FirstName>
+        <LastName>Davis</LastName>
+        <Age>61</Age>
+        <City>Toronto</City>
+        <Friends>
+            <Friend reference="103" />
+            <Friend reference="113" />
+        </Friends>
+    </Person>
+    <Person id="161">
         <FirstName>Diana</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>59</Age>
+        <City>Belgrade</City>
+        <Friends>
+            <Friend reference="178" />
+            <Friend reference="199" />
+            <Friend reference="92" />
+            <Friend reference="191" />
+            <Friend reference="130" />
+        </Friends>
+    </Person>
+    <Person id="162">
+        <FirstName>Angela</FirstName>
+        <LastName>Brown</LastName>
+        <Age>23</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="131" />
+        </Friends>
+    </Person>
+    <Person id="163">
+        <FirstName>Angela</FirstName>
+        <LastName>Brown</LastName>
+        <Age>68</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="32" />
+            <Friend reference="71" />
+            <Friend reference="169" />
+        </Friends>
+    </Person>
+    <Person id="164">
+        <FirstName>Steve</FirstName>
+        <LastName>Brown</LastName>
+        <Age>18</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="20" />
+        </Friends>
+    </Person>
+    <Person id="165">
+        <FirstName>Hank</FirstName>
         <LastName>Williams</LastName>
+        <Age>64</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="193" />
+            <Friend reference="199" />
+            <Friend reference="134" />
+            <Friend reference="51" />
+            <Friend reference="162" />
+        </Friends>
+    </Person>
+    <Person id="166">
+        <FirstName>Hank</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>35</Age>
+        <City>Washington</City>
+        <Friends>
+            <Friend reference="78" />
+        </Friends>
+    </Person>
+    <Person id="167">
+        <FirstName>Jack</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>41</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="22" />
+        </Friends>
+    </Person>
+    <Person id="168">
+        <FirstName>Hank</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>19</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="175" />
+        </Friends>
+    </Person>
+    <Person id="169">
+        <FirstName>Hank</FirstName>
+        <LastName>Parker</LastName>
+        <Age>64</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="95" />
+            <Friend reference="142" />
+            <Friend reference="52" />
+        </Friends>
+    </Person>
+    <Person id="170">
+        <FirstName>Ivy</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>40</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="39" />
+            <Friend reference="151" />
+            <Friend reference="31" />
+            <Friend reference="18" />
+            <Friend reference="71" />
+        </Friends>
+    </Person>
+    <Person id="171">
+        <FirstName>Hank</FirstName>
+        <LastName>Williams</LastName>
+        <Age>44</Age>
+        <City>New York</City>
+        <Friends>
+            <Friend reference="34" />
+            <Friend reference="53" />
+            <Friend reference="128" />
+            <Friend reference="4" />
+            <Friend reference="165" />
+        </Friends>
+    </Person>
+    <Person id="172">
+        <FirstName>Frank</FirstName>
+        <LastName>Miller</LastName>
+        <Age>31</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="156" />
+            <Friend reference="56" />
+        </Friends>
+    </Person>
+    <Person id="173">
+        <FirstName>Jack</FirstName>
+        <LastName>Smith</LastName>
         <Age>77</Age>
         <City>Paris</City>
         <Friends>
-            <Friend reference="ad4964fd-ac44-4613-9af1-55de566f7c39" />
-            <Friend reference="03c2b774-d323-414b-93e2-5451e2508393" />
-            <Friend reference="155c9358-eb9a-413c-80c8-550a716d53fb" />
+            <Friend reference="1" />
+            <Friend reference="31" />
+            <Friend reference="185" />
+            <Friend reference="144" />
         </Friends>
     </Person>
-    <Person id="8a29dd15-f5a8-4305-a2f2-3d69b58b7385">
-        <FirstName>Grace</FirstName>
-        <LastName>Johnson</LastName>
-        <Age>18</Age>
-        <City>Paris</City>
+    <Person id="174">
+        <FirstName>Hank</FirstName>
+        <LastName>Brown</LastName>
+        <Age>63</Age>
+        <City>London</City>
         <Friends>
-            <Friend reference="3862037c-93a3-4fd9-8311-e73eba84d9d4" />
-            <Friend reference="b10b954a-cf7f-4be2-ac5a-bea8824e7ca5" />
-            <Friend reference="d1afacd2-2ddc-4bfc-afe0-d389bccd8ac8" />
-            <Friend reference="b7979061-e500-41ba-82ed-252a855aa449" />
+            <Friend reference="51" />
+            <Friend reference="159" />
         </Friends>
     </Person>
-    <Person id="cd464b11-884f-4ce9-b864-c449b5d90825">
-        <FirstName>Frank</FirstName>
+    <Person id="175">
+        <FirstName>Bob</FirstName>
+        <LastName>Jones</LastName>
+        <Age>61</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="76" />
+            <Friend reference="174" />
+            <Friend reference="49" />
+            <Friend reference="101" />
+        </Friends>
+    </Person>
+    <Person id="176">
+        <FirstName>Eve</FirstName>
+        <LastName>Jones</LastName>
+        <Age>44</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="130" />
+            <Friend reference="104" />
+            <Friend reference="116" />
+            <Friend reference="6" />
+        </Friends>
+    </Person>
+    <Person id="177">
+        <FirstName>Charlie</FirstName>
         <LastName>Davis</LastName>
-        <Age>18</Age>
+        <Age>52</Age>
         <City>Belgrade</City>
         <Friends>
-            <Friend reference="335d7a0a-dcb6-41d9-b75c-e6f54a32da71" />
-            <Friend reference="9ac4ec64-f272-4652-bccb-f86b0b32e833" />
-            <Friend reference="b755e758-8ab3-4afc-91ec-4aa0bd8f2bf1" />
-            <Friend reference="24b7a10f-7391-4d12-9e50-a81f8da6c8b1" />
+            <Friend reference="77" />
         </Friends>
     </Person>
-    <Person id="515b1f72-c812-4bf8-9db5-16cce515a096">
-        <FirstName>Jack</FirstName>
+    <Person id="178">
+        <FirstName>Bob</FirstName>
+        <LastName>Parker</LastName>
+        <Age>68</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="67" />
+        </Friends>
+    </Person>
+    <Person id="179">
+        <FirstName>Grace</FirstName>
+        <LastName>Davis</LastName>
+        <Age>22</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="88" />
+        </Friends>
+    </Person>
+    <Person id="180">
+        <FirstName>Eve</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>25</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="176" />
+            <Friend reference="140" />
+            <Friend reference="15" />
+            <Friend reference="7" />
+        </Friends>
+    </Person>
+    <Person id="181">
+        <FirstName>Hank</FirstName>
+        <LastName>Parker</LastName>
+        <Age>73</Age>
+        <City>Belgrade</City>
+        <Friends>
+            <Friend reference="138" />
+            <Friend reference="110" />
+            <Friend reference="11" />
+        </Friends>
+    </Person>
+    <Person id="182">
+        <FirstName>Charlie</FirstName>
+        <LastName>Williams</LastName>
+        <Age>70</Age>
+        <City>Madrid</City>
+        <Friends>
+            <Friend reference="166" />
+        </Friends>
+    </Person>
+    <Person id="183">
+        <FirstName>Alice</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>34</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="157" />
+            <Friend reference="37" />
+            <Friend reference="193" />
+            <Friend reference="50" />
+            <Friend reference="11" />
+        </Friends>
+    </Person>
+    <Person id="184">
+        <FirstName>Hank</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>33</Age>
+        <City>London</City>
+        <Friends>
+            <Friend reference="102" />
+            <Friend reference="103" />
+            <Friend reference="186" />
+            <Friend reference="47" />
+            <Friend reference="153" />
+        </Friends>
+    </Person>
+    <Person id="185">
+        <FirstName>Ivy</FirstName>
+        <LastName>Johnson</LastName>
+        <Age>34</Age>
+        <City>Washington</City>
+        <Friends>
+            <Friend reference="42" />
+            <Friend reference="48" />
+            <Friend reference="158" />
+            <Friend reference="67" />
+        </Friends>
+    </Person>
+    <Person id="186">
+        <FirstName>Steve</FirstName>
+        <LastName>Parker</LastName>
+        <Age>18</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="177" />
+            <Friend reference="185" />
+        </Friends>
+    </Person>
+    <Person id="187">
+        <FirstName>Steve</FirstName>
+        <LastName>Williams</LastName>
+        <Age>56</Age>
+        <City>Belgrade</City>
+        <Friends>
+            <Friend reference="150" />
+        </Friends>
+    </Person>
+    <Person id="188">
+        <FirstName>David</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>78</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="21" />
+            <Friend reference="175" />
+            <Friend reference="94" />
+            <Friend reference="151" />
+        </Friends>
+    </Person>
+    <Person id="189">
+        <FirstName>Eve</FirstName>
+        <LastName>Williams</LastName>
+        <Age>58</Age>
+        <City>Toronto</City>
+        <Friends>
+            <Friend reference="35" />
+            <Friend reference="163" />
+            <Friend reference="82" />
+        </Friends>
+    </Person>
+    <Person id="190">
+        <FirstName>Steve</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>37</Age>
+        <City>Paris</City>
+        <Friends>
+            <Friend reference="139" />
+            <Friend reference="69" />
+            <Friend reference="116" />
+            <Friend reference="123" />
+        </Friends>
+    </Person>
+    <Person id="191">
+        <FirstName>Eve</FirstName>
         <LastName>Garcia</LastName>
+        <Age>24</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="59" />
+            <Friend reference="89" />
+            <Friend reference="69" />
+            <Friend reference="79" />
+            <Friend reference="102" />
+        </Friends>
+    </Person>
+    <Person id="192">
+        <FirstName>Bob</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>27</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="191" />
+            <Friend reference="123" />
+            <Friend reference="92" />
+            <Friend reference="62" />
+            <Friend reference="75" />
+        </Friends>
+    </Person>
+    <Person id="193">
+        <FirstName>Hank</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>38</Age>
+        <City>Washington</City>
+        <Friends>
+            <Friend reference="42" />
+            <Friend reference="170" />
+        </Friends>
+    </Person>
+    <Person id="194">
+        <FirstName>Martin</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>80</Age>
+        <City>Tokyo</City>
+        <Friends>
+            <Friend reference="166" />
+        </Friends>
+    </Person>
+    <Person id="195">
+        <FirstName>Charlie</FirstName>
+        <LastName>Dickinson</LastName>
+        <Age>79</Age>
+        <City>Rome</City>
+        <Friends>
+            <Friend reference="186" />
+            <Friend reference="91" />
+            <Friend reference="167" />
+            <Friend reference="1" />
+        </Friends>
+    </Person>
+    <Person id="196">
+        <FirstName>Angela</FirstName>
+        <LastName>Garcia</LastName>
+        <Age>43</Age>
+        <City>Sydney</City>
+        <Friends>
+            <Friend reference="28" />
+            <Friend reference="72" />
+            <Friend reference="134" />
+            <Friend reference="13" />
+        </Friends>
+    </Person>
+    <Person id="197">
+        <FirstName>Steve</FirstName>
+        <LastName>Martinez</LastName>
+        <Age>57</Age>
+        <City>Berlin</City>
+        <Friends>
+            <Friend reference="23" />
+            <Friend reference="195" />
+            <Friend reference="8" />
+        </Friends>
+    </Person>
+    <Person id="198">
+        <FirstName>Bob</FirstName>
+        <LastName>Jones</LastName>
+        <Age>45</Age>
+        <City>Toronto</City>
+        <Friends>
+            <Friend reference="99" />
+            <Friend reference="143" />
+        </Friends>
+    </Person>
+    <Person id="199">
+        <FirstName>Jack</FirstName>
+        <LastName>Wilson</LastName>
         <Age>37</Age>
         <City>New York</City>
         <Friends>
-            <Friend reference="40252399-35ee-4d11-ba8b-001a719497ba" />
-        </Friends>
-    </Person>
-    <Person id="83441d1e-3751-45c7-826b-7bd615fdbaec">
-        <FirstName>Alice</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>54</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="8e237aae-0d64-4c31-85eb-95a7eb3cdea4" />
-            <Friend reference="8556f7fd-b6a6-402a-a333-62a9788caab5" />
-            <Friend reference="d57fb7f5-3eb5-4c12-b4b9-86e31390c7e4" />
-            <Friend reference="a9d9b2cb-a849-4cf0-86d2-f579043c5f0b" />
-            <Friend reference="7db08737-7701-48a9-8a79-9b8c97eda088" />
-        </Friends>
-    </Person>
-    <Person id="a47670a2-b226-4851-9a86-f8f51e8040f7">
-        <FirstName>Jack</FirstName>
-        <LastName>Brown</LastName>
-        <Age>43</Age>
-        <City>Toronto</City>
-        <Friends>
-            <Friend reference="9d2ce7c3-1276-4b7c-8a87-6b5ed60753da" />
-        </Friends>
-    </Person>
-    <Person id="b87a06ee-1e6d-4539-ae2d-c3fe2a7fe3fe">
-        <FirstName>Ivy</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>27</Age>
-        <City>Tokyo</City>
-        <Friends>
-            <Friend reference="0b2c05d0-51d3-4db7-b01a-84bba52804f9" />
-            <Friend reference="4f080671-134e-4470-94e3-fa0ff20c053b" />
-            <Friend reference="35c49b17-a47d-4f03-9e1c-d89a6d2ec1a4" />
-        </Friends>
-    </Person>
-    <Person id="7db08737-7701-48a9-8a79-9b8c97eda088">
-        <FirstName>Jack</FirstName>
-        <LastName>Garcia</LastName>
-        <Age>66</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="c20bda61-fa5f-4f12-b991-3e91a67e40bb" />
-            <Friend reference="14921138-709b-421d-b4bd-300aa0f1a5eb" />
-            <Friend reference="7d3e3c2b-0324-416e-bf9b-90815d8aec90" />
-            <Friend reference="fad1cc81-c784-4f12-973c-c01f70c8aeb3" />
-        </Friends>
-    </Person>
-    <Person id="bd14b1e1-b03d-4d2a-ad18-3352ec625db5">
-        <FirstName>Eve</FirstName>
-        <LastName>Smith</LastName>
-        <Age>60</Age>
-        <City>Berlin</City>
-        <Friends>
-            <Friend reference="7717505e-c0da-449c-8077-ff5e0fc31053" />
-            <Friend reference="4eb57e1b-f0cd-4535-9b30-4f711df52897" />
-        </Friends>
-    </Person>
-    <Person id="a47c22d1-6279-475e-869b-8b9c644ab099">
-        <FirstName>Eve</FirstName>
-        <LastName>Davis</LastName>
-        <Age>44</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="f2a5ae1d-731a-4e22-a097-62048fddde2a" />
-            <Friend reference="0b75944b-3bb8-4859-bfe9-c6969ee6087a" />
-            <Friend reference="ad902f4d-477f-4dc8-ac78-0915ce265808" />
-        </Friends>
-    </Person>
-    <Person id="925194d6-ff51-4afd-9faa-3b741543f803">
-        <FirstName>Alice</FirstName>
-        <LastName>Davis</LastName>
-        <Age>46</Age>
-        <City>London</City>
-        <Friends>
-            <Friend reference="ebb01581-aea4-4ff8-bb00-4d1c673cc03a" />
-            <Friend reference="726ca190-bdb2-45c9-b70f-6625f29dc482" />
-            <Friend reference="e35289b1-ad46-4b44-b34b-59fc5246a808" />
-        </Friends>
-    </Person>
-    <Person id="7bdbe39f-ffdc-409a-a671-899fce3ff56e">
-        <FirstName>Diana</FirstName>
-        <LastName>Brown</LastName>
-        <Age>77</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="78c8043b-2aa8-4ea7-a5db-bc978f1d5804" />
-            <Friend reference="9ac4ec64-f272-4652-bccb-f86b0b32e833" />
-        </Friends>
-    </Person>
-    <Person id="93827627-b25b-4514-a9c7-dbaa8a0b0120">
-        <FirstName>Frank</FirstName>
-        <LastName>Davis</LastName>
-        <Age>22</Age>
-        <City>Sydney</City>
-        <Friends>
-            <Friend reference="db43912a-fc76-4286-a017-479c11da344a" />
-        </Friends>
-    </Person>
-    <Person id="d1afacd2-2ddc-4bfc-afe0-d389bccd8ac8">
-        <FirstName>Alice</FirstName>
-        <LastName>Smith</LastName>
-        <Age>63</Age>
-        <City>Rome</City>
-        <Friends>
-            <Friend reference="9017d323-0a52-443d-a966-bb4cfd391927" />
-        </Friends>
-    </Person>
-    <Person id="472ec1f0-d72a-4c7c-a951-2a6c51c60f25">
-        <FirstName>Grace</FirstName>
-        <LastName>Martinez</LastName>
-        <Age>58</Age>
-        <City>Madrid</City>
-        <Friends>
-            <Friend reference="25f00dbf-bae2-4c23-a43d-12a97337a354" />
-            <Friend reference="1c8e478d-53b0-4aec-974b-e670a5cd2019" />
-            <Friend reference="0a07c6e5-f50b-4070-94ed-1192e57be736" />
-            <Friend reference="116ee3ff-dde2-415d-b573-927cf83ca146" />
-            <Friend reference="9d2ce7c3-1276-4b7c-8a87-6b5ed60753da" />
+            <Friend reference="72" />
+            <Friend reference="133" />
+            <Friend reference="152" />
+            <Friend reference="89" />
         </Friends>
     </Person>
 </People>

--- a/graph_explorer/webgraph/static/style.css
+++ b/graph_explorer/webgraph/static/style.css
@@ -275,3 +275,89 @@ a:hover {
 .file-upload-container {
   padding-bottom: 0;
 }
+
+#graph-terminal {
+    background: #ffffff;
+    color: #222;
+    font-family: 'Inter', sans-serif;
+    padding: 1rem;
+    border-radius: 12px;
+    min-height: 250px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    border: 1px solid #ddd;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.05);
+}
+
+#terminal-output {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem;
+    border-bottom: 1px solid #eee;
+    margin-bottom: 0.5rem;
+}
+
+.terminal-command {
+    color: #0078ff;
+    font-weight: 600;
+}
+
+.terminal-output-line {
+    color: #333;
+}
+
+.terminal-input {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.terminal-prompt {
+    font-weight: bold;
+    color: #0078ff;
+}
+
+#cli-input {
+    flex: 1;
+    background: #f9f9f9;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    color: #222;
+    font-family: 'Inter', sans-serif;
+    font-size: 1rem;
+    padding: 0.3rem 0.5rem;
+}
+
+#cli-input:focus {
+    outline: none;
+    border: 1px solid #0078ff;
+    box-shadow: 0 0 6px rgba(0,120,255,0.2);
+}
+
+.terminal-commands-list {
+    background: #f9f9f9;
+    border: 1px solid #ddd;
+    border-radius: 12px;
+    padding: 0.75rem 1rem;
+    margin-top: 1rem;
+}
+
+.terminal-commands-list h4 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    font-size: 1rem;
+    color: #0078ff;
+}
+
+.terminal-commands-list ul {
+    padding-left: 1.2rem;
+    margin: 0;
+}
+
+.terminal-commands-list ul li {
+    margin-bottom: 0.4rem;
+    font-family: 'Inter', sans-serif;
+    font-size: 0.9rem;
+    color: #333;
+}

--- a/graph_explorer/webgraph/templates/base.html
+++ b/graph_explorer/webgraph/templates/base.html
@@ -139,6 +139,46 @@
             {{ graph_view_header|safe }}
             {{ graph_view_body|safe }}
         </div>
+        <div class="controls glass card" id="graph-terminal">
+            <h3>Graph CLI</h3>
+
+            <div id="terminal-output">
+                {% for line in request.session.terminal_history %}
+                    {% if line.type == "command" %}
+                        <div class="terminal-command">{{ line.text }}</div>
+                    {% else %}
+                        <div class="terminal-output-line">{{ line.text }}</div>
+                    {% endif %}
+                {% endfor %}
+            </div>
+
+            <div style="display: flex; gap: 0.5rem; align-items: center;">
+                <form action="{% url 'terminal_command' %}" method="post" style="flex: 1; display: flex; gap: 0.5rem;">
+                    {% csrf_token %}
+                    <span class="terminal-prompt">&gt;</span>
+                    <input type="text" name="command" id="cli-input" placeholder="Enter command..." autocomplete="off" style="flex: 1;" />
+                    <button type="submit" class="btn secondary">Run</button>
+                </form>
+
+                <form method="post" action="{% url 'clear_terminal' %}">
+                    {% csrf_token %}
+                    <button type="submit" class="btn secondary">Clear Terminal</button>
+                </form>
+            </div>
+
+            <div class="terminal-commands-list glass card">
+                <h4>Allowed Commands</h4>
+                <ul>
+                    <li>create node --id=&lt;id&gt; --property &lt;name&gt;=&lt;value&gt;</li>
+                    <li>create edge &lt;id1&gt; &lt;id2&gt;</li>
+                    <li>edit node --id=&lt;id&gt; --property &lt;name&gt;=&lt;value&gt;</li>
+                    <li>delete node --id=&lt;id&gt;</li>
+                    <li>delete edge &lt;id1&gt; &lt;id2&gt;</li>
+                    <li>filter &lt;attribute&gt;&lt;operator&gt;&lt;value&gt;</li>
+                    <li>search &lt;keyword&gt;</li>
+                </ul>
+            </div>
+          </div>
     </div>
 </div>
 </body>

--- a/graph_explorer/webgraph/urls.py
+++ b/graph_explorer/webgraph/urls.py
@@ -13,4 +13,6 @@ urlpatterns = [
     path('reset', views.reset_graph, name="reset_graph"),
     path('remove_search/<int:index>/', views.remove_search, name="remove_search"),
     path('remove_filter/<int:index>/', views.remove_filter, name="remove_filter"),
+    path('terminal', views.terminal_command, name='terminal_command'),
+    path("terminal/clear/", views.clear_terminal, name="clear_terminal"),
 ]

--- a/graph_explorer/webgraph/views.py
+++ b/graph_explorer/webgraph/views.py
@@ -4,6 +4,7 @@ from django.http import HttpResponse
 from django.shortcuts import render, redirect
 from graph.use_cases.plugin_recognition import PluginService
 from graph.use_cases.graph_main_view import MainView
+from graph.use_cases.executor import GraphCLI
 from .apps import datasource_group, visualizer_group
 
 def _get_active_workspace(request):
@@ -169,3 +170,63 @@ def delete_workspace(request, name):
         request.session["workspaces"] = workspaces
         request.session.modified = True
     return redirect("index")
+
+def terminal_command(request):
+    if request.method != "POST":
+        return redirect("index")
+
+    command = request.POST.get("command", "").strip()
+    if not command:
+        return redirect("index")
+
+    if command.lower() == "cls":
+        return clear_terminal(request)
+
+    workspace, workspaces = _get_active_workspace(request)
+    if workspace is not None:
+        tokens = command.split(maxsplit=1)
+        cmd_type = tokens[0].lower()
+        rest = tokens[1].strip() if len(tokens) > 1 else ""
+
+        if cmd_type == "filter" and rest:
+            filters = workspace.get("filters", [])
+            for cond in rest.split("&&"):
+                cond = cond.strip()
+                for op in ["==", "!=", ">=", "<=", ">", "<"]:
+                    if op in cond:
+                        parts = cond.split(op, 1)
+                        if len(parts) == 2:
+                            attr, val = parts
+                            filters.append({
+                                "attr": attr.strip(),
+                                "op": op,
+                                "val": val.strip()
+                            })
+                        break
+            workspace["filters"] = filters
+
+        elif cmd_type == "search" and rest:
+            searches = workspace.get("searches", [])
+            keyword = rest.split()[0]
+            searches.append(keyword)
+            workspace["searches"] = searches
+
+        else:
+            cli_commands = workspace.get("cli_commands", [])
+            cli_commands.append(command)
+            workspace["cli_commands"] = cli_commands
+
+        request.session["workspaces"] = workspaces
+        request.session.modified = True
+
+    history = request.session.get("terminal_history", [])
+    history.append({"text": f"> {command}", "type": "command"})
+    request.session["terminal_history"] = history
+
+    return redirect("index")
+
+def clear_terminal(request):
+    if "terminal_history" in request.session:
+        request.session["terminal_history"] = []
+        request.session.modified = True
+        return redirect("index")

--- a/platform/graph/use_cases/command.py
+++ b/platform/graph/use_cases/command.py
@@ -1,0 +1,81 @@
+from abc import ABC, abstractmethod
+from graph.api.models import Graph, Node, Edge
+from typing import Dict
+
+
+class Command(ABC):
+    @abstractmethod
+    def execute(self, graph: Graph):
+        pass
+
+
+class CreateNodeCommand(Command):
+    def __init__(self, node_id, properties: Dict[str, str]):
+        self.node_id = node_id
+        self.properties = properties
+
+    def execute(self, graph: Graph):
+        if not self.node_id or self.node_id in graph._nodes:
+            return
+        node = Node(self.node_id, self.properties)
+        graph.add_node(node)
+
+
+class EditNodeCommand(Command):
+    def __init__(self, node_id, properties: Dict[str, str]):
+        self.node_id = node_id
+        self.properties = properties or {}
+
+    def execute(self, graph: Graph):
+        node = graph._nodes.get(self.node_id)
+        if not node:
+            return
+        for k, v in self.properties.items():
+            node.set_value(k, v)
+
+
+class DeleteNodeCommand(Command):
+    def __init__(self, node_id):
+        self.node_id = node_id
+
+    def execute(self, graph: Graph):
+        node = graph._nodes.get(self.node_id)
+        if not node:
+            return
+        # Ako čvor ima bilo koju ivicu, ne briši
+        if any(e.from_node.node_id == self.node_id or e.to_node.node_id == self.node_id for e in graph._edges):
+            return
+        del graph._nodes[self.node_id]
+
+
+class CreateEdgeCommand(Command):
+    def __init__(self, from_id, to_id):
+        self.from_id = from_id
+        self.to_id = to_id
+
+    def execute(self, graph: Graph):
+        from_node = graph._nodes.get(self.from_id)
+        to_node = graph._nodes.get(self.to_id)
+        if not from_node or not to_node:
+            return
+        if any(e.from_node.node_id == self.from_id and e.to_node.node_id == self.to_id for e in graph._edges):
+            return
+        graph.add_edge(Edge(from_node, to_node))
+
+
+class DeleteEdgeCommand(Command):
+    def __init__(self, from_id, to_id):
+        self.from_id = from_id
+        self.to_id = to_id
+
+    def execute(self, graph: Graph):
+        edge = next((e for e in graph._edges if e.from_node.node_id == self.from_id and e.to_node.node_id == self.to_id), None)
+        if edge:
+            graph._edges.remove(edge)
+
+
+class ClearGraphCommand(Command):
+    def execute(self, graph: Graph):
+        graph._nodes.clear()
+        graph._edges.clear()
+

--- a/platform/graph/use_cases/executor.py
+++ b/platform/graph/use_cases/executor.py
@@ -1,0 +1,19 @@
+from .parser import parse_command
+
+class GraphCLI:
+    _instance = None
+
+    def __init__(self, graph):
+        self.graph = graph
+
+    @classmethod
+    def get_instance(cls, graph=None):
+        if cls._instance is None and graph is not None:
+            cls._instance = GraphCLI(graph)
+        return cls._instance
+
+    def run(self, cmd_str):
+        cmd = parse_command(cmd_str)
+        if not cmd:
+            return f"Unknown command: {cmd_str}"
+        cmd.execute(self.graph)

--- a/platform/graph/use_cases/filter_service.py
+++ b/platform/graph/use_cases/filter_service.py
@@ -31,7 +31,7 @@ class FilterService:
         except ValueError:
             pass
 
-        for fmt in ("%Y-%m-%d", "%d.%m.%Y", "%Y/%m/%d"):
+        for fmt in ("%Y-%m-%d", "%d.%m.%Y.", "%Y/%m/%d"):
             try:
                 return datetime.strptime(value, fmt)
             except ValueError:

--- a/platform/graph/use_cases/graph_main_view.py
+++ b/platform/graph/use_cases/graph_main_view.py
@@ -3,6 +3,7 @@ import os
 from .const import DATASOURCE_GROUP, VISUALIZER_GROUP
 from graph.use_cases.search_service import SearchService
 from graph.use_cases.filter_service import FilterService
+from .executor import GraphCLI
 from .plugin_recognition import PluginService
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "../../../simple_visualizer/templates")
@@ -15,7 +16,7 @@ class MainView(object):
     def render(self, datasource_id: str, visualizer_id: str, **kwargs) -> (str, str):
         if not datasource_id or not visualizer_id:
             return "", ""
-        
+
         request = kwargs.get("request")
         workspace = kwargs.get("workspace")
 
@@ -41,6 +42,13 @@ class MainView(object):
                         filters = workspace.get("filters", [])
                         if filters:
                             graph = FilterService.apply_filters(graph, filters)
+
+                        cli_commands = workspace.get("cli_commands", [])
+                        if cli_commands:
+                            cli = GraphCLI(graph)
+                            for cmd in cli_commands:
+                                cli.run(cmd)
+                            graph = cli.graph
 
                 except Exception as e:
                     print("Datasource plugin error:", e)

--- a/platform/graph/use_cases/parser.py
+++ b/platform/graph/use_cases/parser.py
@@ -1,0 +1,92 @@
+from .command import (
+    CreateNodeCommand, CreateEdgeCommand,
+    EditNodeCommand, DeleteNodeCommand,
+    DeleteEdgeCommand, ClearGraphCommand
+)
+
+
+def parse_command(cmd_str: str):
+    tokens = cmd_str.strip().split()
+    if not tokens:
+        return None
+
+    cmd_type = tokens[0].lower()
+
+    if cmd_type == "create":
+        if len(tokens) < 2:
+            return None
+
+        if tokens[1] == "node":
+            node_id = None
+            props = {}
+            i = 2
+            while i < len(tokens):
+                token = tokens[i]
+                if token.startswith("--id="):
+                    node_id = token.split("=", 1)[1]
+                elif token == "--property" and i + 1 < len(tokens):
+                    prop_pair = tokens[i + 1]
+                    if "=" in prop_pair:
+                        k, v = prop_pair.split("=", 1)
+                        props[k] = v
+                    i += 1
+                i += 1
+            if node_id is None:
+                return None
+            return CreateNodeCommand(node_id, props)
+
+        if tokens[1] == "edge":
+            if len(tokens) < 4:
+                return None
+            from_id = tokens[2]
+            to_id = tokens[3]
+            return CreateEdgeCommand(from_id, to_id)
+
+    if cmd_type == "edit":
+        if len(tokens) < 2:
+            return None
+
+        if tokens[1] == "node":
+            node_id = None
+            props = {}
+            i = 2
+            while i < len(tokens):
+                token = tokens[i]
+                if token.startswith("--id="):
+                    node_id = token.split("=", 1)[1]
+                elif token == "--property" and i + 1 < len(tokens):
+                    prop_pair = tokens[i + 1]
+                    if "=" in prop_pair:
+                        k, v = prop_pair.split("=", 1)
+                        props[k] = v
+                    i += 1
+                i += 1
+            if node_id is None:
+                return None
+            return EditNodeCommand(node_id, props)
+
+    if cmd_type == "delete":
+        if len(tokens) < 2:
+            return None
+
+        if tokens[1] == "node":
+            node_id = None
+            for t in tokens[2:]:
+                if t.startswith("--id="):
+                    node_id = t.split("=", 1)[1]
+                    break
+            if node_id is None:
+                return None
+            return DeleteNodeCommand(node_id)
+
+        if tokens[1] == "edge":
+            if len(tokens) < 4:
+                return None
+            from_id = tokens[2]
+            to_id = tokens[3]
+            return DeleteEdgeCommand(from_id, to_id)
+
+    if cmd_type == "clear":
+        return ClearGraphCommand()
+
+    return None


### PR DESCRIPTION
This PR implements a terminal-style CLI feature for the graph workspace, enabling users to interactively manage graph data. The CLI supports:

Node Commands:
- create node --id=<id> --property <name>=<value> – create a new node with optional properties
- edit node --id=<id> --property <name>=<value> – edit properties of an existing node
- delete node --id=<id> – remove a node (only if it has no connected edges)

Edge Commands:
- create edge <id1> <id2> – create a new edge between two nodes
- delete edge <id1> <id2> – remove an existing edge

Graph Queries:
- filter <attribute><operator><value> – filter nodes based on attribute conditions (==, !=, >, <, >=, <=)
- search <keyword> – search for nodes by keyword in their attributes

Additional Features:
- All CLI actions are recorded per workspace and persisted in session storage
- Users can clear the terminal output with cls
- Filters, searches, and CLI history provide a flexible interface for exploring and manipulating graph data directly from the workspace

These enhancements make the workspace fully interactive, allowing users to manage nodes, edges, and graph queries efficiently from a single terminal interface.